### PR TITLE
fix wrong account selection in eventsManager for duplicate addresses

### DIFF
--- a/src/hooks/useWalletConnectEventsManager.ts
+++ b/src/hooks/useWalletConnectEventsManager.ts
@@ -22,7 +22,7 @@ enum Errors {
 export default function useWalletConnectEventsManager(initialized: boolean) {
 	const { navigate, routes, tabsIndexes } = useNavigation()
 	const removeSession = useSessionsStore(sessionSelector.removeSession)
-	const accounts = useAccountsStore(accountSelector.selectAccounts)
+	const accounts = useAccountsStore(accountSelector.selectAccountsConnected)
 
 	const { initWalletApiClient, closeTransport } = useLedgerLive()
 	/******************************************************************************

--- a/src/pages/proposal.tsx
+++ b/src/pages/proposal.tsx
@@ -1,3 +1,4 @@
+import { Account } from '@ledgerhq/wallet-api-client'
 import { ButtonsContainer, List } from '@/components/atoms/containers/Elements'
 import { GenericRow, RowType } from '@/components/atoms/GenericRow'
 import LogoContainer from '@/components/atoms/logoContainers/LedgerLogoContainer'
@@ -16,6 +17,7 @@ import {
 	CircledCrossSolidMedium,
 } from '@ledgerhq/react-ui/assets/icons'
 import Image from 'next/image'
+import { accountSelector, useAccountsStore } from '@/storage/accounts.store'
 import { space } from '@ledgerhq/react-ui/styles/theme'
 import { useTranslation } from 'next-i18next'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -65,6 +67,9 @@ export default function SessionProposal() {
 	const { t } = useTranslation()
 	const { hydrated } = useHydratation()
 	const proposal = JSON.parse(router.query.data as string) as Proposal
+	const setAccountsConnected = useAccountsStore(
+		accountSelector.setAccountsConnected,
+	)
 	const {
 		handleClick,
 		handleClose,
@@ -93,6 +98,16 @@ export default function SessionProposal() {
 			url: proposer?.metadata?.url,
 		})
 		approveSession()
+		setAccountsConnected(
+			selectedAccounts
+				.map((id) => {
+					const acc: Account | undefined = accounts.find(
+						(a) => a.id === id,
+					)
+					return acc
+				})
+				.filter((acc): acc is Account => !!acc),
+		)
 	}
 
 	const onReject = useCallback(() => {

--- a/src/storage/accounts.store.ts
+++ b/src/storage/accounts.store.ts
@@ -4,8 +4,10 @@ import { persist } from 'zustand/middleware'
 
 interface AccountsState {
 	accounts: Account[]
+	accountsConnected: Account[]
 	addAccounts: (accounts: Account[]) => void
 	addAccount: (account: Account) => void
+	setAccountsConnected: (account: Account[]) => void
 	clearAccounts: () => void
 }
 
@@ -13,6 +15,9 @@ const useAccountsStore = create<AccountsState>()(
 	persist(
 		(set) => ({
 			accounts: [],
+			accountsConnected: [],
+			setAccountsConnected: (accounts: Account[]) =>
+				set(() => ({ accountsConnected: accounts })),
 			addAccounts: (accounts: Account[]) =>
 				set(() => ({ accounts: accounts })),
 			addAccount: (account: Account) =>
@@ -27,9 +32,12 @@ const useAccountsStore = create<AccountsState>()(
 
 const accountSelector = {
 	selectAccounts: (state: AccountsState): Account[] => state.accounts,
+	selectAccountsConnected: (state: AccountsState): Account[] =>
+		state.accountsConnected,
 	addAccounts: (state: AccountsState) => state.addAccounts,
 	addAccount: (state: AccountsState) => state.addAccount,
 	clearAccounts: (state: AccountsState) => state.clearAccounts,
+	setAccountsConnected: (state: AccountsState) => state.setAccountsConnected,
 }
 
 export { useAccountsStore, accountSelector }


### PR DESCRIPTION
Hello, on ledger-vault we are facing a problem with walletconnect v2. I'm not 100% sure it's a bug on the live app or on our side, but this is what I understood:

- When we have two accounts with the same address (one is ethereum, the other one is polygon), they get both[ passed to wallet connect](https://github.com/LedgerHQ/wallet-connect-live-app/blob/feat/new-v2-without-v1/src/pages/index.tsx#L71).
- Then they are saved in some kind of session [here](https://github.com/LedgerHQ/wallet-connect-live-app/blob/feat/new-v2-without-v1/src/components/screens/index.tsx#L47). 
- Then no matter what accounts we chose to connect during the "proposal" screens, [the full list of accounts](https://github.com/LedgerHQ/wallet-connect-live-app/blob/feat/new-v2-without-v1/src/hooks/useWalletConnectEventsManager.ts#L25) is used to [find](https://github.com/LedgerHQ/wallet-connect-live-app/blob/feat/new-v2-without-v1/src/hooks/useWalletConnectEventsManager.ts#L60) the account to interact with. As `hasETHAddress()` function is finding by address, it just takes the first one it finds in the original full accounts list.

To solve it, I tried to set in the session the real list of accounts that are connected during the proposal screen, then we use that list (and not the full list) to find the account to interact with.

I'm  *really* not sure it is the right way to solve it. For example, I don't know if it's technically possible to connect matic & polygon accounts at the same time during the `proposal` screen, **but if it's the case this commit won't solve the issue.**

So this PR is more a way to open the discussion and get some help on this issue. 

### Demo

| before  | after |
|-----------|--------|
|![bugwc](https://github.com/LedgerHQ/wallet-connect-live-app/assets/944835/4911a0cc-6860-489b-b151-27d6ec5bdb30)|![fixwc](https://github.com/LedgerHQ/wallet-connect-live-app/assets/944835/1da1fc9b-db63-46b7-a7dc-38732922abd0)|


