### PR TITLE
VG-16377 handle transaction with no recipient

### DIFF
--- a/src/shared/helpers/__tests__/converter.test.ts
+++ b/src/shared/helpers/__tests__/converter.test.ts
@@ -8,7 +8,7 @@ describe("Converter File", () => {
     const expected = {
       family: "ethereum",
       amount: new BigNumber(ethTx.value.replace("0x", ""), 16),
-      recipient: eip55.encode(ethTx.to),
+      recipient: ethTx.to ? eip55.encode(ethTx.to) : "",
       gasPrice: new BigNumber(ethTx.gasPrice.replace("0x", ""), 16),
       gasLimit: new BigNumber(ethTx.gas.replace("0x", ""), 16),
       data: Buffer.from(ethTx.data.replace("0x", ""), "hex"),
@@ -30,7 +30,28 @@ describe("Converter File", () => {
     const expected = {
       family: "ethereum",
       amount: new BigNumber(0),
-      recipient: eip55.encode(ethTx.to),
+      recipient: eip55.encode(to),
+      gasPrice: new BigNumber(0),
+      gasLimit: new BigNumber(0),
+      data: undefined,
+    }
+    const converted = convertEthToLiveTX(ethTx)
+
+    expect(converted).toEqual(expected)
+  })
+
+  it("convertEthToLiveTX should handle TX without recipient", async () => {
+    const ethTx: EthTransaction = {
+      value: "",
+      gasPrice: "",
+      gas: "",
+      data: "",
+    }
+
+    const expected = {
+      family: "ethereum",
+      amount: new BigNumber(0),
+      recipient: "",
       gasPrice: new BigNumber(0),
       gasLimit: new BigNumber(0),
       data: undefined,

--- a/src/shared/helpers/converters.ts
+++ b/src/shared/helpers/converters.ts
@@ -4,7 +4,7 @@ import { EthereumTransaction } from "@ledgerhq/wallet-api-client"
 
 export type EthTransaction = {
   value: string
-  to: string
+  to?: string
   gasPrice: string
   gas: string
   data: string
@@ -17,7 +17,7 @@ export function convertEthToLiveTX(ethTX: EthTransaction): EthereumTransaction {
       ethTX.value !== undefined
         ? new BigNumber(ethTX.value.replace("0x", ""), 16)
         : new BigNumber(0),
-    recipient: eip55.encode(ethTX.to),
+    recipient: ethTX.to ? eip55.encode(ethTX.to) : "",
     gasPrice:
       ethTX.gasPrice !== undefined
         ? new BigNumber(ethTX.gasPrice.replace("0x", ""), 16)


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Some transaction don't have any recipient. For instance, using remix IDE you can trigger a transaction to deploy a smart contract, it will generate a transaction without a `to` field.

This is the quickest solution, perhaps not the cleanest. We just build an `EthereumTransaction` with an empty string in the `recipient` field and let the consumer of the live app handle this case.

The other solution would be to change wallet-api types..etc.., but not sure it is worth it.

Tested on the vault with no issue, not sure what are the impacts for ledger-live though.

### ❓ Context

- **Linked resource(s)**: `VG-16377` <!-- Attach any ticket number if relevant. (JIRA / Github issue number) -->


### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
