### PR TITLE
refactor: vite test analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "i18next": "^23.8.2",
     "i18next-http-backend": "^2.4.3",
     "jotai": "^2.6.4",
+    "jotai-tanstack-query": "^0.8.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^14.0.5",
     "react-qr-reader": "2.2.1",
     "react-transition-group": "^4.4.2",
     "styled-components": "^5.3.11",
+    "wonka": "^6.3.4",
     "zustand": "^4.3.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ dependencies:
   jotai:
     specifier: ^2.6.4
     version: 2.6.4(@types/react@18.2.55)(react@18.2.0)
+  jotai-tanstack-query:
+    specifier: ^0.8.5
+    version: 0.8.5(@tanstack/query-core@5.20.2)(jotai@2.6.4)(wonka@6.3.4)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -83,6 +86,9 @@ dependencies:
   styled-components:
     specifier: ^5.3.11
     version: 5.3.11(@babel/core@7.23.9)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
+  wonka:
+    specifier: ^6.3.4
+    version: 6.3.4
   zustand:
     specifier: ^4.3.3
     version: 4.5.0(@types/react@18.2.55)(react@18.2.0)
@@ -1608,6 +1614,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.5
+      napi-wasm: 1.1.0
     bundledDependencies:
       - napi-wasm
 
@@ -6345,6 +6352,18 @@ packages:
     resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
     hasBin: true
 
+  /jotai-tanstack-query@0.8.5(@tanstack/query-core@5.20.2)(jotai@2.6.4)(wonka@6.3.4):
+    resolution: {integrity: sha512-cFq+1sE7Qkt7Kh9Db2KE8LXdbPiGwCiy8S5YSEnjUDxF59A4XhoXTDJBuPiMIA1dD1/yMsNKr1ADfN5CvscYZw==}
+    peerDependencies:
+      '@tanstack/query-core': '*'
+      jotai: '>=2.0.0'
+      wonka: ^6.3.4
+    dependencies:
+      '@tanstack/query-core': 5.20.2
+      jotai: 2.6.4(@types/react@18.2.55)(react@18.2.0)
+      wonka: 6.3.4
+    dev: false
+
   /jotai@2.6.4(@types/react@18.2.55)(react@18.2.0):
     resolution: {integrity: sha512-RniwQPX4893YlNR1muOtyUGHYaTD1fhEN4qnOuZJSrDHj6xdEMrqlRSN/hCm2fshwk78ruecB/P2l+NCVWe6TQ==}
     engines: {node: '>=12.20.0'}
@@ -6738,6 +6757,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
+
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -8422,6 +8444,10 @@ packages:
       siginfo: 2.0.0
       stackback: 0.0.2
     dev: true
+
+  /wonka@6.3.4:
+    resolution: {integrity: sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==}
+    dev: false
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}

--- a/src/routes/root.tsx
+++ b/src/routes/root.tsx
@@ -13,7 +13,6 @@ import useWalletConnect from "@/hooks/useWalletConnect";
 import { InputMode } from "@/types/types";
 import i18n from "@/i18n";
 import { useConnect } from "@/hooks/useConnect";
-// import useAnalytics from "@/hooks/common/useAnalytics";
 
 // eslint-disable-next-line react-refresh/only-export-components
 const TanStackRouterDevtools = import.meta.env.PROD
@@ -51,18 +50,6 @@ function WalletConnectInit() {
 
   return null;
 }
-
-// // TODO Migrate to analytics provider or jotai atom that will get the wallet-api infos by itself
-// // eslint-disable-next-line react-refresh/only-export-components
-// function AnalyticsInit() {
-//   const analytics = useAnalytics();
-
-//   useEffect(() => {
-//     analytics.start(userId, walletInfo);
-//   }, [analytics]);
-
-//   return null;
-// }
 
 // Create a client
 const twentyFourHoursInMs = 1000 * 60 * 60 * 24;

--- a/src/store/analytics.store.ts
+++ b/src/store/analytics.store.ts
@@ -1,0 +1,16 @@
+import { atom } from "jotai";
+import { walletAPIwalletInfoAtom } from "./wallet-api.store";
+
+export const analyticsWriteKeyAtom = atom(async (get) => {
+  const { data: walletInfo } = await get(walletAPIwalletInfoAtom);
+  const walletName = walletInfo.wallet.name;
+
+  let writeKey: string | undefined = undefined;
+
+  if (walletName === "ledger-live-desktop") {
+    writeKey = import.meta.env.VITE_PUBLIC_SEGMENT_API_KEY_DESKTOP;
+  } else if (walletName === "ledger-live-mobile") {
+    writeKey = import.meta.env.VITE_PUBLIC_SEGMENT_API_KEY_MOBILE;
+  }
+  return writeKey
+})

--- a/src/store/wallet-api.store.ts
+++ b/src/store/wallet-api.store.ts
@@ -3,6 +3,7 @@ import {
   WalletAPIClient,
   WindowMessageTransport,
 } from "@ledgerhq/wallet-api-client";
+import { atomWithSuspenseQuery } from "jotai-tanstack-query";
 // import {
 //   getSimulatorTransport,
 //   profiles,
@@ -35,4 +36,26 @@ export const walletAPIClientAtom = atom((get) => {
   const transport = get(transportAtom);
 
   return new WalletAPIClient(transport);
+});
+
+export const walletAPIuserIdAtom = atomWithSuspenseQuery((get) => {
+  const client = get(walletAPIClientAtom);
+  return {
+    queryKey: ["userId", client.notify], // TODO: have a better way to differentiate clients
+    queryFn: async () => {
+      const client = get(walletAPIClientAtom);
+      return client.wallet.userId();
+    },
+  };
+});
+
+export const walletAPIwalletInfoAtom = atomWithSuspenseQuery((get) => {
+  const client = get(walletAPIClientAtom);
+  return {
+    queryKey: ["walletInfo", client.notify], // TODO : have a better way to differentiate clients
+    queryFn: async () => {
+      const client = get(walletAPIClientAtom);
+      return client.wallet.info();
+    },
+  };
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -43,3 +43,15 @@ vi.mock("@walletconnect/core", () => {
     }),
   };
 });
+
+vi.mock("@/hooks/useAnalytics", () => {
+  return {
+    default: () => {
+      return {
+        track: vi.fn(),
+        identify: vi.fn(),
+        page: vi.fn(),
+      };
+    },
+  };
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Documentation on AnalyticsBrowser: https://github.com/segmentio/analytics-next/tree/master/packages/browser
The `.load()` function on it can be called on the AnalyticsBrowser [after it has been created](https://github.com/segmentio/analytics-next/tree/master/packages/browser#lazy--delayed-loading), this is what I use below and it avoids having to check for the `analytic` presence, as its always going to be defined now.

The whole AnalyticsBrowser creation cannot be simply moved as an atom as it's type turns into `[Analytics, Context]` when created by deference. So it has to be initialized as undefined instead, and the checks downstream (`if !analytics`) would have to be kept. So, this code below works but isn't that great and adds confusion IMO 

```js
export const analyticsAtom = atom(async (get) => {
  const { data: walletInfo } = await get(walletAPIwalletInfoAtom);
  const writeKey = await get(analyticsWriteKeyAtom)
 let analytics;

  if (walletInfo.tracking && writeKey) {
    [analytics,] = await AnalyticsBrowser.load({writeKey});
  } 
    return analytics
});

...

  const [analytics]: Analytics | undefined = useAtom(analyticsAtom);
```

### ❓ Context

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->


### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ