### PR TITLE
fix: Verify API usage on proposal

### DIFF
--- a/src/hooks/useVerification.ts
+++ b/src/hooks/useVerification.ts
@@ -1,4 +1,4 @@
-import { walletKitAtom } from "@/store/walletKit.store";
+import { verifyContextByTopicAtom } from "@/store/walletKit.store";
 import { VerificationStatus } from "@/types/types";
 import { ProposalTypes } from "@walletconnect/types";
 import { useAtomValue } from "jotai";
@@ -7,21 +7,19 @@ import { useMemo } from "react";
 const useVerification = (
   proposal: ProposalTypes.Struct,
 ): VerificationStatus => {
-  const walletKit = useAtomValue(walletKitAtom);
+  const verifyContextByTopic = useAtomValue(verifyContextByTopicAtom);
 
-  return useMemo(
-    () =>
-      proposal.proposer.metadata.verifyUrl ??
-      walletKit.core.pairing
-        .getPairings()
-        .find((pairing) => pairing.topic === proposal.pairingTopic)
-        ?.peerMetadata?.verifyUrl ??
-      "UNKNOWN",
-    [
-      proposal.pairingTopic,
-      proposal.proposer.metadata.verifyUrl,
-      walletKit.core.pairing,
-    ],
-  ) as VerificationStatus;
+  return useMemo<VerificationStatus>(() => {
+    const context = verifyContextByTopic[proposal.pairingTopic];
+    if (!context) {
+      return "UNKNOWN";
+    }
+
+    if (context.verified.isScam) {
+      return "SCAM";
+    }
+
+    return context.verified.validation;
+  }, [proposal.pairingTopic, verifyContextByTopic]);
 };
 export default useVerification;

--- a/src/store/walletKit.store.ts
+++ b/src/store/walletKit.store.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
 import { Core } from "@walletconnect/core";
+import type { Verify } from "@walletconnect/types";
 import { WalletKit } from "@reown/walletkit";
 
 const relayerURL = "wss://relay.walletconnect.com";
@@ -31,3 +32,7 @@ export const walletKitAtom = atom((get) => {
 export const loadingAtom = atom(false);
 
 export const showBackToBrowserModalAtom = atom(false);
+
+export type VerifyContextByTopic = Record<string, Verify.Context>;
+
+export const verifyContextByTopicAtom = atom<VerifyContextByTopic>({});


### PR DESCRIPTION
### 📝 Description

`proposal.proposer.metadata.verifyUrl` could be a string after loading and we don't want to use the URL but a `VerificationStatus`

### ❓ Context

- **Linked resource(s)**: []

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
