### PR TITLE
fix: disable sol until we can enable it only for some versions of LL

### DIFF
--- a/src/data/network.config.ts
+++ b/src/data/network.config.ts
@@ -230,7 +230,7 @@ export const SUPPORTED_NETWORK: Record<string, Network> = {
   ...MULTIVERS_X_CHAINS,
   ...BIP122_CHAINS,
   ...RIPPLE_CHAINS,
-  ...SOLANA_CHAINS,
+  // ...SOLANA_CHAINS,
 };
 
 export const SUPPORTED_NETWORK_NAMES: string[] = Object.values(
@@ -242,5 +242,5 @@ export enum SupportedNamespace {
   EIP155 = "eip155",
   MVX = "mvx",
   XRPL = "xrpl",
-  SOLANA = "solana",
+  // SOLANA = "solana",
 }

--- a/src/hooks/requestHandlers/Wallet.ts
+++ b/src/hooks/requestHandlers/Wallet.ts
@@ -14,14 +14,14 @@ import {
   isEIP155Chain,
   isMultiversXChain,
   isRippleChain,
-  isSolanaChain,
+  // isSolanaChain,
 } from "@/utils/helper.util";
 import {
   BIP122_NETWORK_BY_CHAIN_ID,
   EIP155_NETWORK_BY_CHAIN_ID,
   MULTIVERS_X_NETWORK_BY_CHAIN_ID,
   RIPPLE_NETWORK_BY_CHAIN_ID,
-  SOLANA_NETWORK_BY_CHAIN_ID,
+  // SOLANA_NETWORK_BY_CHAIN_ID,
 } from "@/data/network.config";
 import { queryKey as accountsQueryKey } from "@/hooks/useAccounts";
 
@@ -49,9 +49,9 @@ function getNetwork(currentChainId: string, newChainId: string) {
   if (isMultiversXChain(currentChainId)) {
     return getNetworkByChainId(MULTIVERS_X_NETWORK_BY_CHAIN_ID, newChainId);
   }
-  if (isSolanaChain(currentChainId)) {
-    return getNetworkByChainId(SOLANA_NETWORK_BY_CHAIN_ID, newChainId);
-  }
+  // if (isSolanaChain(currentChainId)) {
+  //   return getNetworkByChainId(SOLANA_NETWORK_BY_CHAIN_ID, newChainId);
+  // }
 }
 
 const addNewAccounts = async (

--- a/src/hooks/useSupportedNamespaces.ts
+++ b/src/hooks/useSupportedNamespaces.ts
@@ -2,14 +2,14 @@ import { BIP122_SIGNING_METHODS } from "@/data/methods/BIP122.methods";
 import { EIP155_SIGNING_METHODS } from "@/data/methods/EIP155Data.methods";
 import { MULTIVERSX_SIGNING_METHODS } from "@/data/methods/MultiversX.methods";
 import { RIPPLE_SIGNING_METHODS } from "@/data/methods/Ripple.methods";
-import { SOLANA_SIGNING_METHODS } from "@/data/methods/Solana.methods";
+// import { SOLANA_SIGNING_METHODS } from "@/data/methods/Solana.methods";
 import { WALLET_METHODS } from "@/data/methods/Wallet.methods";
 import {
   BIP122_CHAINS,
   EIP155_CHAINS,
   MULTIVERS_X_CHAINS,
   RIPPLE_CHAINS,
-  SOLANA_CHAINS,
+  // SOLANA_CHAINS,
   SupportedNamespace,
 } from "@/data/network.config";
 import useAccounts from "@/hooks/useAccounts";
@@ -276,80 +276,80 @@ export function useSupportedNamespaces(
     [accounts.data, session, selectedAccounts],
   );
 
-  const buildSolanaNamespace = useCallback(
-    (
-      requiredNamespaces: ProposalTypes.RequiredNamespaces,
-      optionalNamespaces: ProposalTypes.OptionalNamespaces,
-    ) => {
-      const accountsByChain = formatAccountsByChain(
-        session,
-        accounts.data,
-      ).filter(
-        (a) =>
-          a.accounts.length > 0 &&
-          a.isSupported &&
-          Object.keys(SOLANA_CHAINS).includes(a.chain),
-      );
+  // const buildSolanaNamespace = useCallback(
+  //   (
+  //     requiredNamespaces: ProposalTypes.RequiredNamespaces,
+  //     optionalNamespaces: ProposalTypes.OptionalNamespaces,
+  //   ) => {
+  //     const accountsByChain = formatAccountsByChain(
+  //       session,
+  //       accounts.data,
+  //     ).filter(
+  //       (a) =>
+  //         a.accounts.length > 0 &&
+  //         a.isSupported &&
+  //         Object.keys(SOLANA_CHAINS).includes(a.chain),
+  //     );
 
-      const supportedMethods: string[] = [
-        ...Object.values(WALLET_METHODS),
-        ...Object.values(SOLANA_SIGNING_METHODS),
-      ];
+  //     const supportedMethods: string[] = [
+  //       ...Object.values(WALLET_METHODS),
+  //       ...Object.values(SOLANA_SIGNING_METHODS),
+  //     ];
 
-      const isLegacy =
-        requiredNamespaces[SupportedNamespace.SOLANA]?.chains?.[0] ===
-          "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ" ||
-        optionalNamespaces[SupportedNamespace.SOLANA]?.chains?.[0] ===
-          "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ";
+  //     const isLegacy =
+  //       requiredNamespaces[SupportedNamespace.SOLANA]?.chains?.[0] ===
+  //         "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ" ||
+  //       optionalNamespaces[SupportedNamespace.SOLANA]?.chains?.[0] ===
+  //         "solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ";
 
-      const dataToSend = accountsByChain.reduce<
-        { account: string; chain: string }[]
-      >(
-        (accum, elem) =>
-          accum.concat(
-            elem.accounts
-              .filter((acc) => selectedAccounts.includes(acc.id))
-              .map((a) => {
-                let currency = a.currency;
-                if (isLegacy) {
-                  currency = "solana (legacy)";
-                }
-                return {
-                  account: `${getNamespace(currency)}:${a.address}`,
-                  chain: getNamespace(currency),
-                };
-              }),
-          ),
-        [],
-      );
+  //     const dataToSend = accountsByChain.reduce<
+  //       { account: string; chain: string }[]
+  //     >(
+  //       (accum, elem) =>
+  //         accum.concat(
+  //           elem.accounts
+  //             .filter((acc) => selectedAccounts.includes(acc.id))
+  //             .map((a) => {
+  //               let currency = a.currency;
+  //               if (isLegacy) {
+  //                 currency = "solana (legacy)";
+  //               }
+  //               return {
+  //                 account: `${getNamespace(currency)}:${a.address}`,
+  //                 chain: getNamespace(currency),
+  //               };
+  //             }),
+  //         ),
+  //       [],
+  //     );
 
-      const methods = [
-        ...new Set([
-          ...(requiredNamespaces[SupportedNamespace.SOLANA]?.methods.filter(
-            (method) => supportedMethods.includes(method),
-          ) ?? []),
-          ...(optionalNamespaces[SupportedNamespace.SOLANA]?.methods.filter(
-            (method) => supportedMethods.includes(method),
-          ) ?? []),
-        ]),
-      ];
+  //     const methods = [
+  //       ...new Set([
+  //         ...(requiredNamespaces[SupportedNamespace.SOLANA]?.methods.filter(
+  //           (method) => supportedMethods.includes(method),
+  //         ) ?? []),
+  //         ...(optionalNamespaces[SupportedNamespace.SOLANA]?.methods.filter(
+  //           (method) => supportedMethods.includes(method),
+  //         ) ?? []),
+  //       ]),
+  //     ];
 
-      const events = [
-        ...new Set([
-          ...(requiredNamespaces[SupportedNamespace.SOLANA]?.events ?? []),
-          ...(optionalNamespaces[SupportedNamespace.SOLANA]?.events ?? []),
-        ]),
-      ];
+  //     const events = [
+  //       ...new Set([
+  //         ...(requiredNamespaces[SupportedNamespace.SOLANA]?.events ?? []),
+  //         ...(optionalNamespaces[SupportedNamespace.SOLANA]?.events ?? []),
+  //       ]),
+  //     ];
 
-      return {
-        chains: [...new Set(dataToSend.map((e) => e.chain))],
-        methods,
-        events,
-        accounts: dataToSend.map((e) => e.account),
-      };
-    },
-    [accounts.data, session, selectedAccounts],
-  );
+  //     return {
+  //       chains: [...new Set(dataToSend.map((e) => e.chain))],
+  //       methods,
+  //       events,
+  //       accounts: dataToSend.map((e) => e.account),
+  //     };
+  //   },
+  //   [accounts.data, session, selectedAccounts],
+  // );
 
   const buildSupportedNamespaces = useCallback(
     (session: SessionTypes.Struct | ProposalTypes.Struct) => {
@@ -382,12 +382,12 @@ export function useSupportedNamespaces(
           optionalNamespaces,
         );
       }
-      if ("solana" in requiredNamespaces || "solana" in optionalNamespaces) {
-        supportedNamespaces[SupportedNamespace.SOLANA] = buildSolanaNamespace(
-          requiredNamespaces,
-          optionalNamespaces,
-        );
-      }
+      // if ("solana" in requiredNamespaces || "solana" in optionalNamespaces) {
+      //   supportedNamespaces[SupportedNamespace.SOLANA] = buildSolanaNamespace(
+      //     requiredNamespaces,
+      //     optionalNamespaces,
+      //   );
+      // }
       return supportedNamespaces;
     },
     [
@@ -395,7 +395,7 @@ export function useSupportedNamespaces(
       buildEip155Namespace,
       buildMvxNamespace,
       buildXrpNamespace,
-      buildSolanaNamespace,
+      // buildSolanaNamespace,
     ],
   );
 

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -2,7 +2,6 @@ import { SignClientTypes } from "@walletconnect/types";
 import { useCallback, useEffect } from "react";
 import { WalletKitTypes } from "@reown/walletkit";
 import { enqueueSnackbar } from "notistack";
-import { getErrorMessage, isSolanaChain } from "@/utils/helper.util";
 import {
   coreAtom,
   connectionStatusAtom,
@@ -17,6 +16,8 @@ import {
   isMultiversXChain,
   isBIP122Chain,
   isRippleChain,
+  // isSolanaChain,
+  getErrorMessage,
 } from "@/utils/helper.util";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -36,7 +37,7 @@ import { Errors, rejectRequest } from "./requestHandlers/utils";
 import { handleWalletRequest } from "./requestHandlers/Wallet";
 import { isWalletRequest } from "../utils/helper.util";
 import { OneClickAuthPayload } from "@/types/types";
-import { handleSolanaRequest } from "./requestHandlers/Solana";
+// import { handleSolanaRequest } from "./requestHandlers/Solana";
 
 function useWalletConnectStatus() {
   const core = useAtomValue(coreAtom);
@@ -227,16 +228,16 @@ export default function useWalletConnect() {
               client,
               walletKit,
             );
-          } else if (isSolanaChain(chainId, request)) {
-            await handleSolanaRequest(
-              request,
-              topic,
-              id,
-              chainId,
-              accounts.data,
-              client,
-              walletKit,
-            );
+          // } else if (isSolanaChain(chainId, request)) {
+          //   await handleSolanaRequest(
+          //     request,
+          //     topic,
+          //     id,
+          //     chainId,
+          //     accounts.data,
+          //     client,
+          //     walletKit,
+          //   );
           } else {
             console.error("Not Supported Chain");
             await rejectRequest(


### PR DESCRIPTION
### 📝 Description

disable sol until we can enable it only for some versions of LL

### ❓ Context

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

#### Interaction with previously opened session:
<img width="1115" alt="Screenshot 2025-05-28 at 15 48 59" src="https://github.com/user-attachments/assets/d299849d-12eb-4128-9755-758eccc31534" />

#### Previously opened session on live-app:
<img width="1530" alt="Screenshot 2025-05-28 at 15 49 15" src="https://github.com/user-attachments/assets/76bb3199-4e4a-4199-9fa5-1a8ae1da33de" />


### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ