### PR TITLE
fix: missing zod strictObject on some schemas

### DIFF
--- a/src/data/methods/BIP122.methods.ts
+++ b/src/data/methods/BIP122.methods.ts
@@ -10,12 +10,12 @@ export const BIP122_SIGNING_METHODS = {
   BIP122_SEND_TRANSFERT: "sendTransfer",
 } as const;
 
-export const bip122SignMessageLegacySchema = z.object({
+export const bip122SignMessageLegacySchema = z.strictObject({
   message: z.string(),
   address: z.string(),
 });
 
-export const bip122SignMessageSchema = z.object({
+export const bip122SignMessageSchema = z.strictObject({
   message: z.string(),
   account: z.string(),
   address: z.string().optional(),

--- a/src/data/methods/MultiversX.methods.ts
+++ b/src/data/methods/MultiversX.methods.ts
@@ -10,17 +10,17 @@ export const MULTIVERSX_SIGNING_METHODS = {
   MULTIVERSX_SIGN_MESSAGE: "mvx_signMessage",
 } as const;
 
-export const multiversxSignMessageSchema = z.object({
+export const multiversxSignMessageSchema = z.strictObject({
   message: z.string(),
   account: z.string(),
   address: z.string(),
 });
 
-export const multiversxSignTransactionSchema = z.object({
+export const multiversxSignTransactionSchema = z.strictObject({
   transaction: mvxTransactionSchema,
 });
 
-export const multiversxSignTransactionsSchema = z.object({
+export const multiversxSignTransactionsSchema = z.strictObject({
   transactions: z.array(mvxTransactionSchema),
 });
 

--- a/src/data/methods/Ripple.methods.ts
+++ b/src/data/methods/Ripple.methods.ts
@@ -8,7 +8,7 @@ export const RIPPLE_SIGNING_METHODS = {
   RIPPLE_SIGN_TRANSACTION: "xrpl_signTransaction",
 } as const;
 
-export const rippleSignTransactionSchema = z.object({
+export const rippleSignTransactionSchema = z.strictObject({
   tx_json: xrpTransactionSchema,
   autofill: z.boolean().optional(),
   submit: z.boolean().optional(),

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -8,7 +8,7 @@ import { BigNumber } from "bignumber.js";
 import eip55 from "eip55";
 import { z } from "zod";
 
-export const ethTransactionSchema = z.object({
+export const ethTransactionSchema = z.strictObject({
   from: z.string(),
   to: z.string().optional(),
   data: z.string().optional(),
@@ -45,7 +45,7 @@ export function convertEthToLiveTX(ethTX: EthTransaction): EthereumTransaction {
   };
 }
 
-export const mvxTransactionSchema = z.object({
+export const mvxTransactionSchema = z.strictObject({
   nonce: z.number(),
   value: z.string(),
   receiver: z.string(),
@@ -76,7 +76,7 @@ export function convertMvxToLiveTX(tx: MvxTransaction): ElrondTransaction {
 
 // Ressource :
 // https://xpring-eng.github.io/xrp-api/XRPAPI-data-types-transaction_common_fields.html
-export const xrpTransactionSchema = z.object({
+export const xrpTransactionSchema = z.strictObject({
   hash: z.string().optional(),
   TransactionType: z.string(),
   Account: z.string(),
@@ -101,7 +101,7 @@ export function convertXrpToLiveTX(tx: XrpTransaction): RippleTransaction {
   return rippleTransaction;
 }
 
-export const btcTransactionSchema = z.object({
+export const btcTransactionSchema = z.strictObject({
   account: z.string(),
   recipientAddress: z.string(),
   amount: z.string(),


### PR DESCRIPTION
### 📝 Description

This pull request updates multiple schema definitions across the codebase to use `z.strictObject` instead of `z.object` for Zod validation. This change enforces strict validation, ensuring that only explicitly defined fields are allowed in the validated objects, which improves data integrity and prevents unexpected properties from being accepted.

Schema validation improvements:

* Updated Ethereum transaction schema in `src/utils/converters.ts` to use `z.strictObject` for stricter validation.
* Updated MultiversX transaction and message schemas in `src/data/methods/MultiversX.methods.ts` and `src/utils/converters.ts` to use `z.strictObject`. [[1]](diffhunk://#diff-12e076c3272dae30c07d6d1a80af61e39f55ec841fe06866233143b312194539L13-R23) [[2]](diffhunk://#diff-91e785a1a34ac08b0f790a60c4285f5f802bcc6491408bebf66c86b2c903ea82L48-R48)
* Updated Ripple transaction schemas in `src/data/methods/Ripple.methods.ts` and `src/utils/converters.ts` to use `z.strictObject`. [[1]](diffhunk://#diff-3c8500f6576d591ee47a6cb494e74bb08b1cf8153ec36d31e4780caf1a41aee8L11-R11) [[2]](diffhunk://#diff-91e785a1a34ac08b0f790a60c4285f5f802bcc6491408bebf66c86b2c903ea82L79-R79)
* Updated BIP122 message schemas in `src/data/methods/BIP122.methods.ts` to use `z.strictObject`.
* Updated Bitcoin transaction schema in `src/utils/converters.ts` to use `z.strictObject`.

### ❓ Context

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ