### PR TITLE
feat(btc): support optional memo field in btcTransactionSchema and update conversion function to liveTx [LIVE-20607]

### DIFF
--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -117,9 +117,9 @@ export const btcTransactionSchema = z.strictObject({
   account: z.string(),
   recipientAddress: z.string(),
   amount: z.string(),
+  memo: z.string().optional(),
   // Uncomment when used in the future
   // changeAddress: z.string().optional(),
-  // memo: z.string().optional(),
 });
 
 export type BtcTransaction = z.infer<typeof btcTransactionSchema>;
@@ -129,5 +129,6 @@ export function convertBtcToLiveTX(btcTX: BtcTransaction): BitcoinTransaction {
     family: "bitcoin",
     amount: btcTX.amount ? new BigNumber(btcTX.amount) : new BigNumber(0),
     recipient: btcTX.recipientAddress,
+    opReturnData: btcTX.memo ? Buffer.from(btcTX.memo, "hex") : undefined,
   };
 }


### PR DESCRIPTION
### 📝 Description

This pull request adds support for an optional memo field to Bitcoin transactions, enabling the handling of OP_RETURN data. The changes update the transaction schema and conversion logic to include and process this new field.

**Bitcoin transaction schema and conversion updates:**

* Added an optional `memo` field to the `btcTransactionSchema` in `src/utils/converters.ts`, allowing transactions to include additional data.
* Updated the `convertBtcToLiveTX` function in `src/utils/converters.ts` to convert the `memo` field to OP_RETURN data (`opReturnData`) if present, using a hex buffer.

### ❓ Context

- **Linked resource(s)**: [LIVE-20607]

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-20607]: https://ledgerhq.atlassian.net/browse/LIVE-20607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ