### PR TITLE
fix(ethereum): add maxFeePerGas and maxPriorityFeePerGas to ethTransactionSchema

### DIFF
--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -14,8 +14,12 @@ export const ethTransactionSchema = z.strictObject({
   data: z.string().optional(),
   gas: z.string().optional(),
   gasPrice: z.string().optional(),
+  maxFeePerGas: z.string().optional(),
+  maxPriorityFeePerGas: z.string().optional(),
   value: z.string().optional(),
   nonce: z.string().optional(),
+  chainId: z.string().optional(),
+  type: z.string().optional(),
 });
 
 export type EthTransaction = z.infer<typeof ethTransactionSchema>;
@@ -37,6 +41,14 @@ export function convertEthToLiveTX(ethTX: EthTransaction): EthereumTransaction {
     gasLimit:
       ethTX.gas !== undefined
         ? new BigNumber(ethTX.gas.replace("0x", ""), 16)
+        : undefined,
+    maxFeePerGas:
+      ethTX.maxFeePerGas !== undefined
+        ? new BigNumber(ethTX.maxFeePerGas.replace("0x", ""), 16)
+        : undefined,
+    maxPriorityFeePerGas:
+      ethTX.maxPriorityFeePerGas !== undefined
+        ? new BigNumber(ethTX.maxPriorityFeePerGas.replace("0x", ""), 16)
         : undefined,
     data: ethTX.data
       ? Buffer.from(ethTX.data.replace("0x", ""), "hex")


### PR DESCRIPTION
### 📝 Description

This pull request updates the Ethereum transaction schema and its conversion logic to support additional transaction fields required for EIP-1559 and chain specification. The main changes are the addition of new optional fields to the schema and their handling in the conversion function.

Schema enhancements:

* Added optional fields `maxFeePerGas`, `maxPriorityFeePerGas`, `chainId`, and `type` to the `ethTransactionSchema` in `src/utils/converters.ts` to support EIP-1559 and chain specification.

Conversion logic updates:

* Updated the `convertEthToLiveTX` function in `src/utils/converters.ts` to correctly convert `maxFeePerGas` and `maxPriorityFeePerGas` from hexadecimal strings to `BigNumber` objects.

### ❓ Context

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ