### PR TITLE
fix(solana): add optional pubkey validation in signTransaction schema

### DIFF
--- a/src/data/methods/Solana.methods.ts
+++ b/src/data/methods/Solana.methods.ts
@@ -37,6 +37,7 @@ export const solanaSignAllTransactionsSchema = z.strictObject({
 
 export const solanaSignTransactionSchema = z.strictObject({
   transaction: z.string(),
+  pubkey: z.string().optional(),
 });
 
 export const solanaSignMessageSchema = z.strictObject({

--- a/src/hooks/requestHandlers/solanaHandlers/signTransaction.ts
+++ b/src/hooks/requestHandlers/solanaHandlers/signTransaction.ts
@@ -36,6 +36,12 @@ export async function signTransaction(
   const liveTransaction = toLiveTransaction(params.transaction);
   const account = findSignerAccount(params.transaction, accounts);
 
+  if (params.pubkey && account.address !== params.pubkey) {
+    throw new Error(
+      `The provided pubkey ${params.pubkey} does not match the account address ${account.address} found in the transaction`,
+    );
+  }
+
   try {
     const signature = await client.transaction.sign(
       account.id,


### PR DESCRIPTION
### 📝 Description

We saw some dApps like Jupiter actually sending a `pubkey` that was not [documented for wallet connect](https://docs.reown.com/advanced/multichain/rpc-reference/solana-rpc#solana-signtransaction)

This pull request introduces an optional `pubkey` parameter to the Solana transaction signing flow, and adds validation to ensure the provided `pubkey` matches the signer account found in the transaction. This helps prevent mismatches and potential security issues when signing transactions.

**Solana transaction signing improvements:**

* Added an optional `pubkey` field to the `solanaSignTransactionSchema` in `Solana.methods.ts`, allowing callers to specify which public key should be used for signing.
* Updated the `signTransaction` handler to check if the provided `pubkey` matches the account address found in the transaction, and throw an error if they do not match.

### ❓ Context

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ