### PR TITLE
fix(solana): add optional pubkey validation and missing optional fields in zod schema

### DIFF
--- a/src/data/methods/Solana.methods.ts
+++ b/src/data/methods/Solana.methods.ts
@@ -14,21 +14,24 @@ export const SOLANA_SIGNING_METHODS = {
 
 export const solanaSignAndSendTransactionSchema = z.strictObject({
   transaction: z.string(),
-  sendOptions: z.strictObject({
-    skipPreflight: z.boolean(),
-    preflightCommitment: z.union([
-      z.literal("processed"),
-      z.literal("confirmed"),
-      z.literal("finalized"),
-      z.literal("recent"),
-      z.literal("single"),
-      z.literal("singleGossip"),
-      z.literal("root"),
-      z.literal("max"),
-    ]),
-    maxRetries: z.number(),
-    minContextSlot: z.number(),
-  }),
+  pubkey: z.string().optional(),
+  sendOptions: z
+    .strictObject({
+      skipPreflight: z.boolean(),
+      preflightCommitment: z.union([
+        z.literal("processed"),
+        z.literal("confirmed"),
+        z.literal("finalized"),
+        z.literal("recent"),
+        z.literal("single"),
+        z.literal("singleGossip"),
+        z.literal("root"),
+        z.literal("max"),
+      ]),
+      maxRetries: z.number(),
+      minContextSlot: z.number(),
+    })
+    .optional(),
 });
 
 export const solanaSignAllTransactionsSchema = z.strictObject({
@@ -38,6 +41,33 @@ export const solanaSignAllTransactionsSchema = z.strictObject({
 export const solanaSignTransactionSchema = z.strictObject({
   transaction: z.string(),
   pubkey: z.string().optional(),
+  // Deprecated fields not compatible with versioned transactions
+  feePayer: z.string().optional(),
+  instructions: z
+    .array(
+      z.strictObject({
+        programId: z.string(),
+        keys: z.array(
+          z.strictObject({
+            pubkey: z.string(),
+            isSigner: z.boolean(),
+            isWritable: z.boolean(),
+          }),
+        ),
+        data: z.string().or(z.array(z.number())).optional(),
+      }),
+    )
+    .optional(),
+  recentBlockhash: z.string().optional(),
+  signatures: z
+    .array(
+      z.strictObject({
+        pubkey: z.string().optional(),
+        publicKey: z.string().optional(),
+        signature: z.string().nullable().optional(),
+      }),
+    )
+    .optional(),
 });
 
 export const solanaSignMessageSchema = z.strictObject({

--- a/src/hooks/requestHandlers/solanaHandlers/signAndSendTransaction.ts
+++ b/src/hooks/requestHandlers/solanaHandlers/signAndSendTransaction.ts
@@ -36,6 +36,12 @@ export async function signAndSendTransaction(
   const liveTransaction = toLiveTransaction(params.transaction);
   const account = findSignerAccount(params.transaction, accounts);
 
+  if (params.pubkey && account.address !== params.pubkey) {
+    throw new Error(
+      `The provided pubkey ${params.pubkey} does not match the account address ${account.address} found in the transaction`,
+    );
+  }
+
   try {
     const signature = await client.transaction.signAndBroadcast(
       account.id,


### PR DESCRIPTION
### 📝 Description

This pull request introduces stricter validation and schema improvements for Solana transaction signing, along with comprehensive tests to ensure correct behavior. The most significant changes include enforcing that the provided `pubkey` matches the account address when signing and sending transactions, updating the schemas to support optional fields and deprecated fields, and adding thorough unit tests to cover these scenarios.

### Validation improvements

* Added logic in `signAndSendTransaction` to throw an error if the provided `pubkey` does not match the account address found in the transaction, preventing mismatched signing attempts (`src/hooks/requestHandlers/solanaHandlers/signAndSendTransaction.ts`).

### Schema enhancements

* Updated `solanaSignAndSendTransactionSchema` to allow an optional `pubkey` and made `sendOptions` optional for greater flexibility in transaction requests (`src/data/methods/Solana.methods.ts`). [[1]](diffhunk://#diff-17f0796f75abb2c4abc253d1de0395b9e17948538026f340c62e3562a97d9cb2L17-R19) [[2]](diffhunk://#diff-17f0796f75abb2c4abc253d1de0395b9e17948538026f340c62e3562a97d9cb2L31-R34)
* Extended `solanaSignTransactionSchema` to include deprecated fields (`feePayer`, `instructions`, `recentBlockhash`, `signatures`), improving compatibility and documentation for versioned transactions (`src/data/methods/Solana.methods.ts`).

### Testing improvements

* Added new unit tests to verify that an error is thrown when the provided `pubkey` does not match the account address, and that signing proceeds successfully when they do match (`src/hooks/requestHandlers/solanaHandlers/signAndSendTransaction.test.ts`).

### ❓ Context

- **Linked resource(s)**: [LIVE-21374]

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-21374]: https://ledgerhq.atlassian.net/browse/LIVE-21374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ