### PR TITLE
fix(bip122): uncomment optional protocol field in signMessage schema [LIVE-21373]

### DIFF
--- a/src/data/methods/BIP122.methods.ts
+++ b/src/data/methods/BIP122.methods.ts
@@ -19,7 +19,9 @@ export const bip122SignMessageSchema = z.strictObject({
   message: z.string(),
   account: z.string(),
   address: z.string().optional(),
-  protocol: z.union([z.literal("ecdsa"), z.literal("bip322")]).optional(),
+  protocol: z
+    .union([z.literal("ecdsa"), z.literal("bip322"), z.literal("")])
+    .optional(),
 });
 
 /**


### PR DESCRIPTION
### 📝 Description

This pull request makes a minor update to the `bip122SignMessageSchema` in `src/data/methods/BIP122.methods.ts` by enabling the `protocol` field. The change allows the schema to accept an optional `protocol` value, supporting both `"ecdsa"` and `"bip322"`.

* Schema update: The `protocol` field is now active and can be set to either `"ecdsa"` or `"bip322"` as an optional property in the `bip122SignMessageSchema`.

### ❓ Context

- **Linked resource(s)**: [LIVE-21373]

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-21373]: https://ledgerhq.atlassian.net/browse/LIVE-21373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ