### PR TITLE
fix(solana): update signature field in solanaSignTransactionSchema to allow object format

### DIFF
--- a/src/data/methods/Solana.methods.ts
+++ b/src/data/methods/Solana.methods.ts
@@ -64,7 +64,11 @@ export const solanaSignTransactionSchema = z.strictObject({
       z.strictObject({
         pubkey: z.string().optional(),
         publicKey: z.string().optional(),
-        signature: z.string().nullable().optional(),
+        signature: z
+          .string()
+          .or(z.object({ type: z.string(), data: z.array(z.number()) }))
+          .nullable()
+          .optional(),
       }),
     )
     .optional(),


### PR DESCRIPTION
### 📝 Description

This pull request updates the schema for Solana transaction signatures to support both string and object formats, increasing flexibility for signature data handling.

Schema update for signature field:

* In `src/data/methods/Solana.methods.ts`, the `signature` field in the `solanaSignTransactionSchema` now accepts either a string or an object with `type` and `data` properties, allowing for broader compatibility with different signature representations.

### ❓ Context

When testing Jito restacking, we couldn't withdraw because of the presence new fields

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ