### PR TITLE
feat: add getAccountAddresses support for BIP122 [LIVE-18131]

### DIFF
--- a/localManifest.json
+++ b/localManifest.json
@@ -51,6 +51,8 @@
     "account.list",
     "account.request",
     "message.sign",
+    "bitcoin.getAddresses",
+    "bitcoin.signPsbt",
     "transaction.sign",
     "transaction.signRaw",
     "transaction.signAndBroadcast",

--- a/src/data/methods/BIP122.methods.ts
+++ b/src/data/methods/BIP122.methods.ts
@@ -11,6 +11,10 @@ export const BIP122_SIGNING_METHODS = {
   BIP122_SIGN_PSBT: "signPsbt",
 } as const;
 
+export const BIP122_QUERY_METHODS = {
+  BIP122_GET_ACCOUNT_ADDRESSES: "getAccountAddresses",
+} as const;
+
 export const bip122SignMessageLegacySchema = z.strictObject({
   message: z.string(),
   address: z.string(),
@@ -40,6 +44,11 @@ export const bip122SignPsbtSchema = z.strictObject({
   broadcast: z.boolean().optional(),
 });
 
+export const bip122GetAccountAddressesSchema = z.strictObject({
+  account: z.string(),
+  intentions: z.array(z.string()).optional(),
+});
+
 /**
  * Requests specs : https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc
  */
@@ -59,7 +68,18 @@ export type BIP122_REQUESTS =
   | {
       method: typeof BIP122_SIGNING_METHODS.BIP122_SIGN_PSBT;
       params: z.infer<typeof bip122SignPsbtSchema>;
+    }
+  | {
+      method: typeof BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES;
+      params: z.infer<typeof bip122GetAccountAddressesSchema>;
     };
+
+export type BIP122AccountAddress = {
+  address: string;
+  publicKey?: string;
+  path?: string;
+  intention?: string;
+};
 
 /**
  * Responses specs : https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc
@@ -78,4 +98,5 @@ export type BIP122_RESPONSES = {
     psbt: string;
     txid?: string;
   };
+  [BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES]: BIP122AccountAddress[];
 };

--- a/src/hooks/__tests__/useProposal.hook.test.ts
+++ b/src/hooks/__tests__/useProposal.hook.test.ts
@@ -1,0 +1,465 @@
+import { renderHook, act, waitFor } from "@/tests/test.utils";
+import { createHookWrapper, type TestStore } from "@/tests/hook-test.utils";
+import { Account } from "@ledgerhq/wallet-api-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import sessionProposal from "@/data/mocks/sessionProposal.example.json";
+import { useProposal } from "../useProposal/useProposal";
+import useAccounts from "../useAccounts";
+import useAnalytics from "../useAnalytics";
+import { useSupportedNamespaces } from "../useSupportedNamespaces";
+import { enqueueSnackbar } from "notistack";
+import { fetchBip122Addresses } from "@/utils/bip122";
+import { createStore } from "jotai";
+import {
+  buildApprovedNamespaces,
+  buildAuthObject,
+  populateAuthPayload,
+} from "@walletconnect/utils";
+
+vi.mock("@/store/walletKit.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    coreAtom: atom(null),
+    walletKitAtom: atom(null),
+    connectionStatusAtom: atom("disconnected"),
+    loadingAtom: atom(false),
+    showBackToBrowserModalAtom: atom(false),
+    verifyContextByTopicAtom: atom({}),
+    oneClickAuthPayloadAtom: atom(undefined),
+  };
+});
+
+vi.mock("@/store/wallet-api.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    walletAPIClientAtom: atom(null),
+    walletInfoAtom: atom(null),
+    walletCapabilitiesAtom: atom([]),
+    transportAtom: atom(null),
+    walletCurrenciesAtom: atom([]),
+    walletCurrenciesByIdAtom: atom({}),
+    walletUserIdAtom: atom(null),
+  };
+});
+
+vi.mock("@/store/recentConnectionAppsAtom", async () => {
+  const { atom } = await import("jotai");
+  return {
+    sortedRecentConnectionAppsAtom: atom(null),
+    recentConnectionAppsAtom: atom({}),
+    initialValue: {},
+  };
+});
+
+vi.mock("../useAccounts", async () => {
+  const actual =
+    await vi.importActual<typeof import("../useAccounts")>("../useAccounts");
+  return {
+    ...actual,
+    default: vi.fn(),
+  };
+});
+
+vi.mock("../useAnalytics", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../useSupportedNamespaces", () => ({
+  useSupportedNamespaces: vi.fn(),
+}));
+
+vi.mock("@/utils/bip122", () => ({
+  fetchBip122Addresses: vi.fn(),
+}));
+
+vi.mock("@walletconnect/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@walletconnect/utils")>(
+      "@walletconnect/utils",
+    );
+  return {
+    ...actual,
+    buildApprovedNamespaces: vi.fn(),
+    buildAuthObject: vi.fn(),
+    populateAuthPayload: vi.fn(),
+  };
+});
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>(
+      "@tanstack/react-router",
+    );
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+import {
+  walletKitAtom,
+  showBackToBrowserModalAtom,
+} from "@/store/walletKit.store";
+import { walletAPIClientAtom } from "@/store/wallet-api.store";
+
+const { useNavigate } = await import("@tanstack/react-router");
+
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedUseAnalytics = vi.mocked(useAnalytics);
+const mockedUseSupportedNamespaces = vi.mocked(useSupportedNamespaces);
+const mockedFetchBip122Addresses = vi.mocked(fetchBip122Addresses);
+const mockedBuildApprovedNamespaces = vi.mocked(buildApprovedNamespaces);
+const mockedBuildAuthObject = vi.mocked(buildAuthObject);
+const mockedPopulateAuthPayload = vi.mocked(populateAuthPayload);
+const mockedUseNavigate = vi.mocked(useNavigate);
+
+function makeAccount(
+  id: string,
+  currency: string,
+  address: string,
+): Account {
+  return {
+    id,
+    name: id,
+    currency,
+    address,
+    balance: 0 as never,
+    spendableBalance: 0 as never,
+    blockHeight: 0,
+    lastSyncDate: new Date("2024-01-01T00:00:00.000Z"),
+  };
+}
+
+describe("useProposal", () => {
+  let store: TestStore;
+  const navigateMock = vi.fn();
+  const analyticsTrackMock = vi.fn();
+
+  const account = makeAccount("eth-1", "ethereum", "0x111");
+  const bitcoinAccount = makeAccount("btc-1", "bitcoin", "bc1qbtc");
+
+  const clientMock = {
+    message: { sign: vi.fn() },
+    account: { request: vi.fn() },
+  };
+
+  const walletKitMock = {
+    approveSession: vi.fn(),
+    approveSessionAuthenticate: vi.fn(),
+    rejectSession: vi.fn(),
+    rejectSessionAuthenticate: vi.fn(),
+    emitSessionEvent: vi.fn(),
+    formatAuthMessage: vi.fn(),
+    engine: {
+      signClient: {
+        session: { getAll: vi.fn().mockReturnValue([]) },
+      },
+    },
+  };
+
+  const buildSupportedNamespacesMock = vi.fn();
+  const buildEip155NamespaceMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.open = vi.fn();
+
+    store = createStore();
+    store.set(walletKitAtom as never, walletKitMock);
+    store.set(walletAPIClientAtom as never, clientMock);
+    store.set(showBackToBrowserModalAtom as never, false);
+
+    mockedUseNavigate.mockReturnValue(navigateMock);
+    mockedUseAnalytics.mockReturnValue({ track: analyticsTrackMock } as never);
+    mockedUseAccounts.mockReturnValue({
+      data: [account, bitcoinAccount],
+    } as ReturnType<typeof useAccounts>);
+    mockedUseSupportedNamespaces.mockReturnValue({
+      buildSupportedNamespaces: buildSupportedNamespacesMock,
+      buildEip155Namespace: buildEip155NamespaceMock,
+    });
+
+    buildSupportedNamespacesMock.mockReturnValue({ eip155: { accounts: [] } });
+    buildEip155NamespaceMock.mockReturnValue({
+      chains: ["eip155:1"],
+      methods: ["personal_sign"],
+      accounts: ["eip155:1:0x111"],
+    });
+    mockedBuildApprovedNamespaces.mockReturnValue({
+      eip155: {
+        accounts: ["eip155:1:0x111"],
+        methods: ["personal_sign"],
+        events: ["accountsChanged"],
+      },
+    } as never);
+    walletKitMock.approveSession.mockResolvedValue({
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          accounts: ["eip155:1:0x111"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+        },
+      },
+      peer: { metadata: { name: "React App" } },
+    });
+    walletKitMock.approveSessionAuthenticate.mockResolvedValue({
+      session: {
+        topic: "topic-1",
+        peer: { metadata: { name: "React App" } },
+      },
+    });
+    walletKitMock.rejectSession.mockResolvedValue(undefined);
+    walletKitMock.rejectSessionAuthenticate.mockResolvedValue(undefined);
+    walletKitMock.emitSessionEvent.mockResolvedValue(undefined);
+    walletKitMock.formatAuthMessage.mockReturnValue("message-to-sign");
+    clientMock.message.sign.mockResolvedValue(Buffer.from("signature"));
+    clientMock.account.request.mockResolvedValue(account);
+    mockedFetchBip122Addresses.mockResolvedValue([
+      { address: "bc1qpayment" },
+    ]);
+    mockedPopulateAuthPayload.mockReturnValue({ aud: "audience" } as never);
+    mockedBuildAuthObject.mockReturnValue({ iss: "eip155:1:0x111" } as never);
+  });
+
+  it("toggles selected accounts through handleClick", () => {
+    const { result } = renderHook(() => useProposal(sessionProposal), {
+      wrapper: createHookWrapper(store),
+    });
+
+    act(() => {
+      result.current.handleClick("eth-1");
+    });
+
+    expect(result.current.selectedAccounts).toEqual(["eth-1"]);
+
+    act(() => {
+      result.current.handleClick("eth-1");
+    });
+
+    expect(result.current.selectedAccounts).toEqual([]);
+  });
+
+  it("approves a session, emits BIP122 addresses, and navigates to the detail page", async () => {
+    walletKitMock.approveSession.mockResolvedValue({
+      topic: "topic-1",
+      namespaces: {
+        bip122: {
+          events: ["bip122_addressesChanged"],
+          accounts: [
+            "bip122:000000000019d6689c085ae165831e93:bc1qbtc",
+            "bip122:000000000019d6689c085ae165831e93:bc1qother",
+          ],
+        },
+      },
+      peer: { metadata: { name: "React App" } },
+    });
+
+    const proposal = {
+      ...sessionProposal,
+      proposer: {
+        ...sessionProposal.proposer,
+        metadata: {
+          ...sessionProposal.proposer.metadata,
+          redirect: {
+            universal: "https://react-app.walletconnect.com",
+          },
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useProposal(proposal), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      await result.current.approveSession();
+    });
+
+    expect(walletKitMock.approveSession).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/detail/$topic",
+        params: { topic: "topic-1" },
+      }),
+    );
+    expect(walletKitMock.emitSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topic: "topic-1",
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        event: expect.objectContaining({
+          name: "bip122_addressesChanged",
+          data: [{ address: "bc1qpayment" }],
+        }),
+        chainId: "bip122:000000000019d6689c085ae165831e93",
+      }),
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      "https://react-app.walletconnect.com",
+    );
+  });
+
+  it("emits BIP122 addresses only once per chain", async () => {
+    walletKitMock.approveSession.mockResolvedValue({
+      topic: "topic-1",
+      namespaces: {
+        bip122: {
+          events: ["bip122_addressesChanged"],
+          accounts: [
+            "bip122:000000000019d6689c085ae165831e93:bc1qbtc",
+            "bip122:000000000019d6689c085ae165831e93:bc1qother",
+          ],
+        },
+      },
+      peer: { metadata: { name: "React App" } },
+    });
+
+    const { result } = renderHook(() => useProposal(sessionProposal), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      await result.current.approveSession();
+    });
+
+    expect(mockedFetchBip122Addresses).toHaveBeenCalledTimes(1);
+  });
+
+  it("signs and approves one-click auth sessions", async () => {
+    const oneClickAuthPayload = {
+      id: 42,
+      topic: "auth-topic",
+      verifyContext: { verified: { origin: "https://app.example" } },
+      params: {
+        authPayload: {
+          domain: "app.example",
+          aud: "https://app.example",
+          nonce: "nonce",
+          type: "eip4361",
+          chains: ["eip155:1"],
+          statement: "Sign in",
+          methods: ["personal_sign"],
+        },
+      },
+    } as never;
+
+    const { result } = renderHook(
+      () => useProposal(sessionProposal, oneClickAuthPayload),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    await act(async () => {
+      await result.current.approveSessionAuthenticate();
+    });
+
+    expect(walletKitMock.approveSessionAuthenticate).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/detail/$topic",
+        params: { topic: "topic-1" },
+      }),
+    );
+  });
+
+  it("rejects a proposal and navigates home", async () => {
+    const proposal = {
+      ...sessionProposal,
+      proposer: {
+        ...sessionProposal.proposer,
+        metadata: {
+          ...sessionProposal.proposer.metadata,
+          redirect: {},
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useProposal(proposal), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      await result.current.rejectSession();
+    });
+
+    expect(walletKitMock.rejectSession).toHaveBeenCalledWith({
+      id: proposal.id,
+      reason: { code: 5000, message: "USER_REJECTED_METHODS" },
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/" }),
+    );
+    expect(store.get(showBackToBrowserModalAtom as never)).toBe(true);
+  });
+
+  it("rejects one-click auth requests with the payload id", async () => {
+    const oneClickAuthPayload = {
+      id: 77,
+      topic: "auth-topic",
+      params: {
+        authPayload: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+        },
+      },
+    } as never;
+
+    const { result } = renderHook(
+      () => useProposal(sessionProposal, oneClickAuthPayload),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    await act(async () => {
+      await result.current.rejectSessionAuthenticate();
+    });
+
+    expect(walletKitMock.rejectSessionAuthenticate).toHaveBeenCalledWith({
+      id: 77,
+      reason: { code: 5000, message: "USER_REJECTED_METHODS" },
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/" }),
+    );
+  });
+
+  it("adds a new account once and selects it", async () => {
+    const newAccount = makeAccount("new-account", "ethereum", "0x999");
+    clientMock.account.request.mockResolvedValue(newAccount);
+
+    const { result } = renderHook(() => useProposal(sessionProposal), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      await result.current.addNewAccount("ethereum");
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedAccounts).toEqual(["new-account"]);
+    });
+
+    await act(async () => {
+      await result.current.addNewAccount("ethereum");
+    });
+
+    expect(result.current.selectedAccounts).toEqual(["new-account"]);
+  });
+
+  it("swallows user-cancelled account creation errors", async () => {
+    clientMock.account.request.mockRejectedValue(new Error("Canceled by user"));
+
+    const { result } = renderHook(() => useProposal(sessionProposal), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      await result.current.addNewAccounts(["ethereum", "bitcoin"]);
+    });
+
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+    expect(result.current.selectedAccounts).toEqual([]);
+  });
+});

--- a/src/hooks/__tests__/useSessionDetails.test.ts
+++ b/src/hooks/__tests__/useSessionDetails.test.ts
@@ -1,0 +1,388 @@
+import { createHookWrapper, type TestStore } from "@/tests/hook-test.utils";
+import { act, renderHook, waitFor } from "@/tests/test.utils";
+import { fetchBip122Addresses } from "@/utils/bip122";
+import { Account } from "@ledgerhq/wallet-api-client";
+import { createStore } from "jotai";
+import { enqueueSnackbar } from "notistack";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useAccounts from "../useAccounts";
+import useAnalytics from "../useAnalytics";
+import { useSessionDetails } from "../useSessionDetails";
+import { useSupportedNamespaces } from "../useSupportedNamespaces";
+
+vi.mock("@/store/walletKit.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    coreAtom: atom(null),
+    walletKitAtom: atom(null),
+    connectionStatusAtom: atom("disconnected"),
+    loadingAtom: atom(false),
+    showBackToBrowserModalAtom: atom(false),
+    verifyContextByTopicAtom: atom({}),
+    oneClickAuthPayloadAtom: atom(undefined),
+  };
+});
+
+vi.mock("@/store/wallet-api.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    walletAPIClientAtom: atom(null),
+    walletInfoAtom: atom(null),
+    walletCapabilitiesAtom: atom([]),
+    transportAtom: atom(null),
+    walletCurrenciesAtom: atom([]),
+    walletCurrenciesByIdAtom: atom({}),
+    walletUserIdAtom: atom(null),
+  };
+});
+
+vi.mock("../useAccounts", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../useAnalytics", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../useSupportedNamespaces", () => ({
+  useSupportedNamespaces: vi.fn(),
+}));
+
+vi.mock("@/utils/bip122", () => ({
+  fetchBip122Addresses: vi.fn(),
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+import { walletAPIClientAtom } from "@/store/wallet-api.store";
+import {
+  showBackToBrowserModalAtom,
+  walletKitAtom,
+} from "@/store/walletKit.store";
+
+const { useNavigate } = await import("@tanstack/react-router");
+
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedUseAnalytics = vi.mocked(useAnalytics);
+const mockedUseSupportedNamespaces = vi.mocked(useSupportedNamespaces);
+const mockedFetchBip122Addresses = vi.mocked(fetchBip122Addresses);
+const mockedUseNavigate = vi.mocked(useNavigate);
+
+function makeAccount(id: string, currency: string, address: string): Account {
+  return {
+    id,
+    name: id,
+    currency,
+    address,
+    balance: 0 as never,
+    spendableBalance: 0 as never,
+    blockHeight: 0,
+    lastSyncDate: new Date("2024-01-01T00:00:00.000Z"),
+  };
+}
+
+describe("useSessionDetails", () => {
+  let store: TestStore;
+  const navigateMock = vi.fn();
+  const analyticsTrackMock = vi.fn();
+
+  const firstEthereumAccount = makeAccount("eth-1", "ethereum", "0x111");
+  const secondEthereumAccount = makeAccount("eth-2", "ethereum", "0x222");
+  const bitcoinAccount = makeAccount("btc-1", "bitcoin", "bc1qbtc");
+
+  const clientMock = {};
+  const walletKitMock = {
+    disconnectSession: vi.fn(),
+    updateSession: vi.fn(),
+    emitSessionEvent: vi.fn(),
+    engine: {
+      signClient: {
+        session: { getAll: vi.fn().mockReturnValue([]) },
+      },
+    },
+  };
+  const buildSupportedNamespacesMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    store = createStore();
+    store.set(walletKitAtom as never, walletKitMock);
+    store.set(walletAPIClientAtom as never, clientMock);
+    store.set(showBackToBrowserModalAtom as never, false);
+
+    mockedUseNavigate.mockReturnValue(navigateMock);
+    mockedUseAnalytics.mockReturnValue({ track: analyticsTrackMock } as never);
+    mockedUseAccounts.mockReturnValue({
+      data: [firstEthereumAccount, secondEthereumAccount, bitcoinAccount],
+    } as ReturnType<typeof useAccounts>);
+    mockedUseSupportedNamespaces.mockReturnValue({
+      buildSupportedNamespaces: buildSupportedNamespacesMock,
+      buildEip155Namespace: vi.fn(),
+    });
+
+    walletKitMock.disconnectSession.mockResolvedValue(undefined);
+    walletKitMock.updateSession.mockResolvedValue(undefined);
+    walletKitMock.emitSessionEvent.mockResolvedValue(undefined);
+    mockedFetchBip122Addresses.mockResolvedValue([{ address: "bc1qpayment" }]);
+    buildSupportedNamespacesMock.mockReturnValue({
+      eip155: {
+        accounts: ["eip155:1:0x111", "eip155:1:0x222"],
+        methods: ["personal_sign"],
+        events: ["accountsChanged"],
+      },
+    });
+  });
+
+  it("initializes session accounts, main account, and selected accounts from the session", async () => {
+    const session = {
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+          accounts: ["eip155:1:0x111", "eip155:1:0x222"],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    } as never;
+
+    const { result } = renderHook(() => useSessionDetails(session), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await waitFor(() => {
+      expect(result.current.mainAccount?.id).toBe("eth-1");
+    });
+
+    expect(result.current.selectedAccounts).toEqual(["eth-1", "eth-2"]);
+    expect(result.current.sessionAccounts).toEqual([
+      ["ethereum", [firstEthereumAccount, secondEthereumAccount]],
+    ]);
+  });
+
+  it("keeps the main account first when it is re-selected", async () => {
+    const session = {
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+          accounts: ["eip155:1:0x111", "eip155:1:0x222"],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    } as never;
+
+    const { result } = renderHook(() => useSessionDetails(session), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedAccounts).toEqual(["eth-1", "eth-2"]);
+    });
+
+    act(() => {
+      result.current.handleClick("eth-1");
+    });
+    act(() => {
+      result.current.handleClick("eth-1");
+    });
+
+    expect(result.current.selectedAccounts).toEqual(["eth-1", "eth-2"]);
+  });
+
+  it("shows an error when confirmEdition is called without selected accounts", async () => {
+    const session = {
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+          accounts: ["eip155:1:0x111"],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    } as never;
+
+    const { result } = renderHook(() => useSessionDetails(session), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedAccounts).toEqual(["eth-1"]);
+    });
+
+    act(() => {
+      result.current.handleClick("eth-1");
+    });
+
+    await act(async () => {
+      await result.current.confirmEdition();
+    });
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "Please select at least one account",
+      expect.objectContaining({ errorType: "Edit session error" }),
+    );
+    expect(walletKitMock.updateSession).not.toHaveBeenCalled();
+  });
+
+  it("updates the session with the chosen main account and navigates back to details", async () => {
+    const session = {
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+          accounts: ["eip155:1:0x111", "eip155:1:0x222"],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    } as never;
+
+    const { result } = renderHook(() => useSessionDetails(session), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await waitFor(() => {
+      expect(result.current.mainAccount?.id).toBe("eth-1");
+    });
+
+    act(() => {
+      result.current.setMainAccount(secondEthereumAccount);
+    });
+
+    await act(async () => {
+      await result.current.confirmEdition();
+    });
+
+    expect(walletKitMock.updateSession).toHaveBeenCalledWith({
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          accounts: ["eip155:1:0x222", "eip155:1:0x111"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+        },
+      },
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "/detail/$topic/edit",
+        to: "/detail/$topic",
+        params: { topic: "topic-1" },
+      }),
+    );
+  });
+
+  it("disconnects the session, tracks analytics, and returns home", async () => {
+    const session = {
+      topic: "topic-1",
+      namespaces: {
+        eip155: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+          events: ["accountsChanged"],
+          accounts: ["eip155:1:0x111"],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    } as never;
+
+    const { result } = renderHook(() => useSessionDetails(session), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      result.current.handleDelete();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(walletKitMock.disconnectSession).toHaveBeenCalledWith({
+        topic: "topic-1",
+        reason: { code: 3, message: "Disconnect Session" },
+      });
+    });
+
+    expect(analyticsTrackMock).toHaveBeenCalledWith("button_clicked", {
+      button: "WC-Disconnect Session",
+      page: "Wallet Connect Session Detail",
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/" }),
+    );
+  });
+
+  it("switches accounts and emits BIP122 session events", async () => {
+    const session = {
+      topic: "topic-1",
+      namespaces: {
+        bip122: {
+          chains: ["bip122:000000000019d6689c085ae165831e93"],
+          methods: ["wallet_getCapabilities"],
+          events: ["bip122_addressesChanged", "accountsChanged"],
+          accounts: ["bip122:000000000019d6689c085ae165831e93:bc1qbtc"],
+        },
+      },
+      requiredNamespaces: {},
+      optionalNamespaces: {},
+    };
+
+    const { result } = renderHook(() => useSessionDetails(session as never), {
+      wrapper: createHookWrapper(store),
+    });
+
+    await act(async () => {
+      await result.current.handleSwitch(bitcoinAccount);
+    });
+
+    expect(walletKitMock.updateSession).toHaveBeenCalledWith({
+      topic: "topic-1",
+      namespaces: session.namespaces,
+    });
+    expect(walletKitMock.emitSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topic: "topic-1",
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        event: expect.objectContaining({
+          name: "bip122_addressesChanged",
+          data: [{ address: "bc1qpayment" }],
+        }),
+      }),
+    );
+    expect(walletKitMock.emitSessionEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        topic: "topic-1",
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        event: expect.objectContaining({
+          name: "accountsChanged",
+          data: ["bc1qbtc"],
+        }),
+      }),
+    );
+    expect(store.get(showBackToBrowserModalAtom as never)).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useSupportedNamespaces.test.ts
+++ b/src/hooks/__tests__/useSupportedNamespaces.test.ts
@@ -1,0 +1,294 @@
+import { renderHook } from "@/tests/test.utils";
+import { createHookWrapper, type TestStore } from "@/tests/hook-test.utils";
+import { Account, WalletInfo } from "@ledgerhq/wallet-api-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import sessionProposal from "@/data/mocks/sessionProposal.example.json";
+import { useSupportedNamespaces } from "../useSupportedNamespaces";
+import useAccounts from "../useAccounts";
+import { formatAccountsByChain } from "../useProposal/util";
+import { createStore } from "jotai";
+
+vi.mock("@/store/wallet-api.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    walletAPIClientAtom: atom(null),
+    walletInfoAtom: atom(null),
+    walletCapabilitiesAtom: atom<string[]>([]),
+    transportAtom: atom(null),
+    walletCurrenciesAtom: atom([]),
+    walletCurrenciesByIdAtom: atom({}),
+    walletUserIdAtom: atom(null),
+  };
+});
+
+vi.mock("../useAccounts", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../useProposal/util", () => ({
+  formatAccountsByChain: vi.fn(),
+}));
+
+import {
+  walletAPIClientAtom,
+  walletInfoAtom,
+  walletCapabilitiesAtom,
+} from "@/store/wallet-api.store";
+
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedFormatAccountsByChain = vi.mocked(formatAccountsByChain);
+
+const baseWalletInfo: WalletInfo["result"] = {
+  wallet: {
+    name: "ledger-live-desktop",
+    version: "2.127.0",
+  },
+  tracking: false,
+};
+
+function makeAccount(
+  id: string,
+  currency: string,
+  address: string,
+): Account {
+  return {
+    id,
+    name: id,
+    currency,
+    address,
+    balance: 0 as never,
+    spendableBalance: 0 as never,
+    blockHeight: 0,
+    lastSyncDate: new Date("2024-01-01T00:00:00.000Z"),
+  };
+}
+
+describe("useSupportedNamespaces", () => {
+  let store: TestStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = createStore();
+
+    store.set(walletAPIClientAtom as never, {});
+    store.set(walletInfoAtom as never, baseWalletInfo);
+    store.set(walletCapabilitiesAtom as never, []);
+
+    mockedUseAccounts.mockReturnValue(
+      { data: [] } as unknown as ReturnType<typeof useAccounts>,
+    );
+  });
+
+  it("returns only selected EIP155 accounts and supported methods/events", () => {
+    const firstEth = makeAccount("eth-1", "ethereum", "0x111");
+    const secondEth = makeAccount("eth-2", "ethereum", "0x222");
+
+    mockedUseAccounts.mockReturnValue({
+      data: [firstEth, secondEth],
+    } as ReturnType<typeof useAccounts>);
+    mockedFormatAccountsByChain.mockReturnValue([
+      {
+        chain: "ethereum",
+        displayName: "Ethereum",
+        isSupported: true,
+        isRequired: true,
+        accounts: [firstEth, secondEth],
+      },
+    ]);
+
+    const proposal = {
+      ...sessionProposal,
+      requiredNamespaces: {
+        eip155: {
+          methods: ["eth_sendTransaction", "wallet_getCapabilities", "bad_method"],
+          chains: ["eip155:1"],
+          events: ["chainChanged"],
+        },
+      },
+      optionalNamespaces: {
+        eip155: {
+          methods: ["personal_sign", "wallet_getCapabilities", "still_bad"],
+          chains: ["eip155:1"],
+          events: ["accountsChanged"],
+        },
+      },
+    };
+
+    const { result } = renderHook(
+      () => useSupportedNamespaces(proposal, ["eth-2"]),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    const namespace = result.current.buildEip155Namespace(
+      proposal.requiredNamespaces,
+      proposal.optionalNamespaces,
+    );
+
+    expect(namespace).toEqual({
+      chains: ["eip155:1"],
+      methods: ["eth_sendTransaction", "personal_sign"],
+      events: ["chainChanged", "accountsChanged"],
+      accounts: ["eip155:1:0x222"],
+    });
+  });
+
+  it("omits XRPL and Solana namespaces when support gates are disabled", () => {
+    const eth = makeAccount("eth-1", "ethereum", "0x111");
+    const btc = makeAccount("btc-1", "bitcoin", "bc1qxyz");
+    const xrp = makeAccount("xrp-1", "ripple", "rXYZ");
+    const sol = makeAccount("sol-1", "solana", "So111");
+
+    mockedUseAccounts.mockReturnValue({
+      data: [eth, btc, xrp, sol],
+    } as ReturnType<typeof useAccounts>);
+
+    store.set(walletInfoAtom as never, {
+      wallet: { name: "ledger-live-desktop", version: "2.125.0" },
+      tracking: false,
+    } satisfies WalletInfo["result"]);
+
+    mockedFormatAccountsByChain.mockReturnValue([
+      {
+        chain: "ethereum",
+        displayName: "Ethereum",
+        isSupported: true,
+        isRequired: true,
+        accounts: [eth],
+      },
+      {
+        chain: "bitcoin",
+        displayName: "Bitcoin",
+        isSupported: true,
+        isRequired: false,
+        accounts: [btc],
+      },
+      {
+        chain: "ripple",
+        displayName: "Ripple",
+        isSupported: true,
+        isRequired: false,
+        accounts: [xrp],
+      },
+      {
+        chain: "solana",
+        displayName: "Solana",
+        isSupported: true,
+        isRequired: false,
+        accounts: [sol],
+      },
+    ]);
+
+    const proposal = {
+      ...sessionProposal,
+      requiredNamespaces: {
+        eip155: {
+          methods: ["personal_sign"],
+          chains: ["eip155:1"],
+          events: ["accountsChanged"],
+        },
+      },
+      optionalNamespaces: {
+        bip122: {
+          methods: ["wallet_getCapabilities"],
+          chains: ["bip122:000000000019d6689c085ae165831e93"],
+          events: ["bip122_addressesChanged"],
+        },
+        xrpl: {
+          methods: ["xrpl_signTransaction"],
+          chains: ["xrpl:0"],
+          events: ["accountsChanged"],
+        },
+        solana: {
+          methods: ["solana_signTransaction"],
+          chains: ["solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"],
+          events: ["accountsChanged"],
+        },
+      },
+    };
+
+    const { result } = renderHook(
+      () => useSupportedNamespaces(proposal, ["eth-1", "btc-1", "xrp-1", "sol-1"]),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    expect(result.current.buildSupportedNamespaces(proposal)).toEqual({
+      eip155: {
+        chains: ["eip155:1"],
+        methods: ["personal_sign"],
+        events: ["accountsChanged"],
+        accounts: ["eip155:1:0x111"],
+      },
+      bip122: {
+        chains: ["bip122:000000000019d6689c085ae165831e93"],
+        methods: [],
+        events: ["bip122_addressesChanged"],
+        accounts: ["bip122:000000000019d6689c085ae165831e93:bc1qxyz"],
+      },
+    });
+  });
+
+  it("includes XRPL and legacy Solana namespaces when support gates are enabled", () => {
+    const xrp = makeAccount("xrp-1", "ripple", "rXYZ");
+    const sol = makeAccount("sol-1", "solana", "So111");
+
+    mockedUseAccounts.mockReturnValue({
+      data: [xrp, sol],
+    } as ReturnType<typeof useAccounts>);
+
+    store.set(walletCapabilitiesAtom as never, ["transaction.signRaw"]);
+
+    mockedFormatAccountsByChain.mockReturnValue([
+      {
+        chain: "ripple",
+        displayName: "Ripple",
+        isSupported: true,
+        isRequired: false,
+        accounts: [xrp],
+      },
+      {
+        chain: "solana",
+        displayName: "Solana",
+        isSupported: true,
+        isRequired: false,
+        accounts: [sol],
+      },
+    ]);
+
+    const proposal = {
+      ...sessionProposal,
+      requiredNamespaces: {
+        xrpl: {
+          methods: ["xrpl_signTransaction"],
+          chains: ["xrpl:0"],
+          events: ["accountsChanged"],
+        },
+        solana: {
+          methods: ["solana_signTransaction"],
+          chains: ["solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ"],
+          events: ["accountsChanged"],
+        },
+      },
+      optionalNamespaces: {},
+    };
+
+    const { result } = renderHook(
+      () => useSupportedNamespaces(proposal, ["xrp-1", "sol-1"]),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    expect(result.current.buildSupportedNamespaces(proposal)).toEqual({
+      xrpl: {
+        chains: ["xrpl:0"],
+        methods: ["xrpl_signTransaction"],
+        events: ["accountsChanged"],
+        accounts: ["xrpl:0:rXYZ"],
+      },
+      solana: {
+        chains: ["solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ"],
+        methods: ["solana_signTransaction"],
+        events: ["accountsChanged"],
+        accounts: ["solana:4sGjMW1sUnHzSxGspuhpqLDx6wiyjNtZ:So111"],
+      },
+    });
+  });
+});

--- a/src/hooks/__tests__/useWalletConnect.test.ts
+++ b/src/hooks/__tests__/useWalletConnect.test.ts
@@ -1,0 +1,385 @@
+import { createHookWrapper, type TestStore } from "@/tests/hook-test.utils";
+import { renderHook, waitFor } from "@/tests/test.utils";
+import { createStore } from "jotai";
+import { enqueueSnackbar } from "notistack";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ZodError } from "zod";
+import { handleBIP122Request } from "../requestHandlers/BIP122";
+import { handleEIP155Request } from "../requestHandlers/EIP155";
+import { handleXrpRequest } from "../requestHandlers/Ripple";
+import { handleSolanaRequest } from "../requestHandlers/Solana";
+import { handleWalletRequest } from "../requestHandlers/Wallet";
+import { Errors, rejectRequest } from "../requestHandlers/utils";
+import useAccounts from "../useAccounts";
+import useWalletConnect from "../useWalletConnect";
+
+vi.mock("@/store/walletKit.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    coreAtom: atom(null),
+    walletKitAtom: atom(null),
+    connectionStatusAtom: atom("disconnected"),
+    loadingAtom: atom(false),
+    showBackToBrowserModalAtom: atom(false),
+    verifyContextByTopicAtom: atom<Record<string, unknown>>({}),
+    oneClickAuthPayloadAtom: atom(undefined),
+  };
+});
+
+vi.mock("@/store/wallet-api.store", async () => {
+  const { atom } = await import("jotai");
+  return {
+    walletAPIClientAtom: atom(null),
+    walletInfoAtom: atom(null),
+    walletCapabilitiesAtom: atom<string[]>([]),
+    transportAtom: atom(null),
+    walletCurrenciesAtom: atom([]),
+    walletCurrenciesByIdAtom: atom({}),
+    walletUserIdAtom: atom(null),
+  };
+});
+
+vi.mock("../useAccounts", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/BIP122", () => ({
+  handleBIP122Request: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/EIP155", () => ({
+  handleEIP155Request: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/Ripple", () => ({
+  handleXrpRequest: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/Solana", () => ({
+  handleSolanaRequest: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/Wallet", () => ({
+  handleWalletRequest: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/utils", () => ({
+  Errors: {
+    unsupportedChains: { message: "unsupported" },
+    txDeclined: { message: "declined" },
+  },
+  rejectRequest: vi.fn(),
+}));
+
+vi.mock("notistack", () => ({
+  enqueueSnackbar: vi.fn(),
+}));
+
+vi.mock("@sentry/react", () => ({
+  withScope: vi.fn((callback) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    callback({
+      setContext: vi.fn(),
+      setTag: vi.fn(),
+      setFingerprint: vi.fn(),
+    });
+  }),
+  captureException: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  };
+});
+
+import {
+  walletAPIClientAtom,
+  walletCapabilitiesAtom,
+  walletInfoAtom,
+} from "@/store/wallet-api.store";
+import {
+  connectionStatusAtom,
+  coreAtom,
+  loadingAtom,
+  oneClickAuthPayloadAtom,
+  showBackToBrowserModalAtom,
+  verifyContextByTopicAtom,
+  walletKitAtom,
+} from "@/store/walletKit.store";
+
+const { useNavigate } = await import("@tanstack/react-router");
+
+const mockedUseAccounts = vi.mocked(useAccounts);
+const mockedHandleWalletRequest = vi.mocked(handleWalletRequest);
+const mockedHandleEIP155Request = vi.mocked(handleEIP155Request);
+const mockedHandleBIP122Request = vi.mocked(handleBIP122Request);
+const mockedHandleXrpRequest = vi.mocked(handleXrpRequest);
+const mockedHandleSolanaRequest = vi.mocked(handleSolanaRequest);
+const mockedRejectRequest = vi.mocked(rejectRequest);
+const mockedUseNavigate = vi.mocked(useNavigate);
+
+describe("useWalletConnect", () => {
+  let store: TestStore;
+  const navigateMock = vi.fn();
+
+  const walletKitListeners = new Map<string, (...args: unknown[]) => void>();
+  const relayerListeners = new Map<string, (...args: unknown[]) => void>();
+
+  const clientMock = {};
+  const accountsMock = [
+    { id: "eth-1", address: "0x111", currency: "ethereum" },
+  ];
+  const sessionRecord = {
+    namespaces: {
+      bip122: {
+        accounts: ["bip122:000000000019d6689c085ae165831e93:bc1qbtc"],
+      },
+    },
+    peer: {
+      metadata: {
+        redirect: {
+          universal: "https://react-app.walletconnect.com",
+        },
+      },
+    },
+  };
+
+  const coreMock = {
+    relayer: {
+      connected: false,
+      on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+        relayerListeners.set(event, callback);
+      }),
+      off: vi.fn(),
+    },
+  };
+
+  const walletKitMock = {
+    on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+      walletKitListeners.set(event, callback);
+    }),
+    off: vi.fn(),
+    engine: {
+      signClient: {
+        session: {
+          get: vi.fn(() => sessionRecord),
+          getAll: vi.fn(() => []),
+        },
+        proposal: {
+          getAll: vi.fn(() => []),
+        },
+      },
+    },
+  };
+
+  const walletInfo = {
+    wallet: { name: "ledger-live-desktop", version: "2.127.0" },
+    tracking: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    walletKitListeners.clear();
+    relayerListeners.clear();
+    coreMock.relayer.connected = false;
+    walletKitMock.engine.signClient.session.get.mockReturnValue(sessionRecord);
+    window.open = vi.fn();
+
+    store = createStore();
+    store.set(coreAtom as never, coreMock);
+    store.set(walletKitAtom as never, walletKitMock);
+    store.set(walletAPIClientAtom as never, clientMock);
+    store.set(walletInfoAtom as never, walletInfo);
+    store.set(walletCapabilitiesAtom as never, ["transaction.signRaw"]);
+    store.set(connectionStatusAtom as never, "disconnected");
+    store.set(loadingAtom as never, false);
+    store.set(showBackToBrowserModalAtom as never, false);
+    store.set(verifyContextByTopicAtom as never, {});
+    store.set(oneClickAuthPayloadAtom as never, undefined);
+
+    mockedUseNavigate.mockReturnValue(navigateMock);
+    mockedUseAccounts.mockReturnValue({
+      data: accountsMock,
+    } as ReturnType<typeof useAccounts>);
+
+    mockedHandleWalletRequest.mockResolvedValue(undefined);
+    mockedHandleEIP155Request.mockResolvedValue(undefined);
+    mockedHandleBIP122Request.mockResolvedValue(undefined);
+    mockedHandleXrpRequest.mockResolvedValue(undefined);
+    mockedHandleSolanaRequest.mockResolvedValue(undefined);
+    mockedRejectRequest.mockResolvedValue(undefined);
+  });
+
+  function mountHook() {
+    return renderHook(() => useWalletConnect(), {
+      wrapper: createHookWrapper(store),
+    });
+  }
+
+  it("shows a connected notification when the relayer is already connected", () => {
+    coreMock.relayer.connected = true;
+
+    mountHook();
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(
+      "Connected to WalletConnect",
+      expect.objectContaining({ connected: true }),
+    );
+  });
+
+  it("handles session proposals by navigating to the proposal page", async () => {
+    mountHook();
+
+    walletKitListeners.get("session_proposal")?.({
+      id: 12,
+      params: { pairingTopic: "pairing-topic" },
+      verifyContext: { verified: { origin: "https://app.example" } },
+    });
+
+    await waitFor(() => {
+      const lastCall = navigateMock.mock.calls.at(-1)?.[0] as
+        | { to?: string; params?: { id?: string } }
+        | undefined;
+      expect(lastCall).toEqual(
+        expect.objectContaining({
+          to: "/proposal/$id",
+          params: { id: "12" },
+        }),
+      );
+    });
+  });
+
+  it.each([
+    {
+      name: "wallet",
+      chainId: "eip155:1",
+      method: "wallet_getCapabilities",
+      handler: () => mockedHandleWalletRequest,
+    },
+    {
+      name: "eip155",
+      chainId: "eip155:1",
+      method: "personal_sign",
+      handler: () => mockedHandleEIP155Request,
+    },
+    {
+      name: "bip122",
+      chainId: "bip122:000000000019d6689c085ae165831e93",
+      method: "btc_getAccountAddresses",
+      handler: () => mockedHandleBIP122Request,
+    },
+    {
+      name: "xrpl",
+      chainId: "xrpl:0",
+      method: "xrpl_signTransaction",
+      handler: () => mockedHandleXrpRequest,
+    },
+    {
+      name: "solana",
+      chainId: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+      method: "solana_signTransaction",
+      handler: () => mockedHandleSolanaRequest,
+    },
+  ])(
+    "dispatches $name requests to the correct handler",
+    async ({ chainId, method, handler }) => {
+      mountHook();
+
+      walletKitListeners.get("session_request")?.({
+        topic: "topic-1",
+        id: 1,
+        params: { chainId, request: { method, params: {} } },
+        verifyContext: {},
+      });
+
+      await waitFor(() => {
+        expect(handler()).toHaveBeenCalled();
+      });
+    },
+  );
+
+  it("rejects unsupported chains", async () => {
+    mountHook();
+
+    walletKitListeners.get("session_request")?.({
+      topic: "topic-1",
+      id: 9,
+      params: {
+        chainId: "cosmos:1",
+        request: { method: "cosmos_signDirect", params: {} },
+      },
+      verifyContext: {},
+    });
+
+    await waitFor(() => {
+      expect(mockedRejectRequest).toHaveBeenCalledWith(
+        walletKitMock,
+        "topic-1",
+        9,
+        Errors.unsupportedChains,
+        5100,
+      );
+    });
+  });
+
+  it("shows an error toast and rejects the request when a handler fails", async () => {
+    mockedHandleEIP155Request.mockRejectedValue(new ZodError([]));
+
+    mountHook();
+
+    walletKitListeners.get("session_request")?.({
+      topic: "topic-1",
+      id: 10,
+      params: {
+        chainId: "eip155:1",
+        request: { method: "personal_sign", params: [] },
+      },
+      verifyContext: {},
+    });
+
+    await waitFor(() => {
+      expect(enqueueSnackbar).toHaveBeenCalled();
+      expect(mockedRejectRequest).toHaveBeenCalledWith(
+        walletKitMock,
+        "topic-1",
+        10,
+        Errors.txDeclined,
+      );
+      expect(window.open).toHaveBeenCalledWith(
+        "https://react-app.walletconnect.com",
+      );
+    });
+  });
+
+  it("stores the one-click auth payload and navigates to the auth screen", async () => {
+    mountHook();
+
+    const payload = {
+      topic: "topic-1",
+      verifyContext: { verified: { origin: "https://app.example" } },
+      params: {
+        authPayload: {
+          chains: ["eip155:1"],
+          methods: ["personal_sign"],
+        },
+      },
+    };
+
+    walletKitListeners.get("session_authenticate")?.(payload);
+
+    await waitFor(() => {
+      expect(store.get(oneClickAuthPayloadAtom as never)).toEqual(payload);
+      const lastCall = navigateMock.mock.calls.at(-1)?.[0] as
+        | { to?: string }
+        | undefined;
+      expect(lastCall).toEqual(
+        expect.objectContaining({ to: "/oneclickauth" }),
+      );
+    });
+  });
+});

--- a/src/hooks/requestHandlers/BIP122.test.ts
+++ b/src/hooks/requestHandlers/BIP122.test.ts
@@ -422,4 +422,61 @@ describe("handleBIP122Request — BIP122_GET_ACCOUNT_ADDRESSES", () => {
       paymentEntry,
     ]);
   });
+
+  it("falls back to the session-selected account when params are undefined (AppKit adapter)", async () => {
+    const acceptSpy = vi.spyOn(utils, "acceptRequest");
+    const client = makeClient(
+      () => Promise.resolve({ psbtSigned: "irrelevant" }),
+      () => Promise.resolve([{ address: testAddress! }]),
+    );
+
+    await handleBIP122Request(
+      {
+        method: BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES,
+        params: undefined as unknown as { account: string },
+      },
+      topic,
+      requestId,
+      BTC_CHAIN_ID,
+      {
+        accounts: [makeAccount()],
+        client,
+        walletkit,
+        sessionAddress: testAddress!,
+      },
+    );
+
+    expect(acceptSpy).toHaveBeenCalledWith(walletkit, topic, requestId, [
+      { address: testAddress! },
+    ]);
+  });
+
+  it("rejects with userDecline when params are undefined and no session account matches", async () => {
+    const rejectSpy = vi.spyOn(utils, "rejectRequest");
+    const client = makeClient(
+      () => Promise.resolve({ psbtSigned: "irrelevant" }),
+    );
+
+    await handleBIP122Request(
+      {
+        method: BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES,
+        params: undefined as unknown as { account: string },
+      },
+      topic,
+      requestId,
+      BTC_CHAIN_ID,
+      {
+        accounts: [makeAccount()],
+        client,
+        walletkit,
+      },
+    );
+
+    expect(rejectSpy).toHaveBeenCalledWith(
+      walletkit,
+      topic,
+      requestId,
+      utils.Errors.userDecline,
+    );
+  });
 });

--- a/src/hooks/requestHandlers/BIP122.test.ts
+++ b/src/hooks/requestHandlers/BIP122.test.ts
@@ -1,4 +1,7 @@
-import { BIP122_SIGNING_METHODS } from "@/data/methods/BIP122.methods";
+import {
+  BIP122_QUERY_METHODS,
+  BIP122_SIGNING_METHODS,
+} from "@/data/methods/BIP122.methods";
 import { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
 import type { IWalletKit } from "@reown/walletkit";
 import BigNumber from "bignumber.js";
@@ -142,7 +145,9 @@ describe("handleBIP122Request — BIP122_SIGN_PSBT", () => {
         BTC_CHAIN_ID,
         {
           accounts: [makeAccount()],
-          client: makeClient(() => Promise.resolve({ psbtSigned: "irrelevant" })),
+          client: makeClient(() =>
+            Promise.resolve({ psbtSigned: "irrelevant" }),
+          ),
           walletkit,
           walletCapabilities: ["bitcoin.signPsbt"],
         },
@@ -321,5 +326,100 @@ describe("handleBIP122Request — BIP122_SIGN_PSBT", () => {
         },
       ),
     ).rejects.toThrow("Network failure");
+  });
+});
+
+describe("handleBIP122Request — BIP122_GET_ACCOUNT_ADDRESSES", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function callGetAccountAddresses(
+    overrides: {
+      params?: Partial<{ account: string; intentions: string[] }>;
+      accounts?: Account[];
+      getAddressesImpl?: (...args: unknown[]) => Promise<unknown>;
+    } = {},
+  ) {
+    const client = makeClient(
+      () => Promise.resolve({ psbtSigned: "irrelevant" }),
+      overrides.getAddressesImpl as
+        | ((accountId: string) => Promise<{ address: string }[]>)
+        | undefined,
+    );
+    return handleBIP122Request(
+      {
+        method: BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES,
+        params: { account: testAddress!, ...overrides.params },
+      },
+      topic,
+      requestId,
+      BTC_CHAIN_ID,
+      {
+        accounts: overrides.accounts ?? [makeAccount()],
+        client,
+        walletkit,
+      },
+    );
+  }
+
+  it("returns the full address list from getAddresses on success", async () => {
+    const acceptSpy = vi.spyOn(utils, "acceptRequest");
+    const entry = {
+      address: testAddress!,
+      publicKey:
+        "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c",
+      path: "m/84'/0'/0'/0/0",
+      intention: "payment",
+    };
+
+    await callGetAccountAddresses({
+      getAddressesImpl: () => Promise.resolve([entry]),
+    });
+
+    expect(acceptSpy).toHaveBeenCalledWith(walletkit, topic, requestId, [
+      entry,
+    ]);
+  });
+
+  it("rejects with userDecline when no account matches the address and chain", async () => {
+    const rejectSpy = vi.spyOn(utils, "rejectRequest");
+
+    await callGetAccountAddresses({ accounts: [] });
+
+    expect(rejectSpy).toHaveBeenCalledWith(
+      walletkit,
+      topic,
+      requestId,
+      utils.Errors.userDecline,
+    );
+  });
+
+  it.each([
+    ["throws", () => Promise.reject(new Error("Unsupported method"))],
+    ["returns empty", () => Promise.resolve([])],
+  ])(
+    "falls back to single-address array when getAddresses %s",
+    async (_, getAddressesImpl) => {
+      const acceptSpy = vi.spyOn(utils, "acceptRequest");
+
+      await callGetAccountAddresses({ getAddressesImpl });
+
+      expect(acceptSpy).toHaveBeenCalledWith(walletkit, topic, requestId, [
+        { address: testAddress! },
+      ]);
+    },
+  );
+
+  it("forwards the intentions param and returns the filtered result", async () => {
+    const acceptSpy = vi.spyOn(utils, "acceptRequest");
+    const paymentEntry = { address: testAddress!, intention: "payment" };
+
+    await callGetAccountAddresses({
+      params: { intentions: ["payment"] },
+      getAddressesImpl: () => Promise.resolve([paymentEntry]),
+    });
+
+    expect(acceptSpy).toHaveBeenCalledWith(walletkit, topic, requestId, [
+      paymentEntry,
+    ]);
   });
 });

--- a/src/hooks/requestHandlers/BIP122.ts
+++ b/src/hooks/requestHandlers/BIP122.ts
@@ -1,11 +1,14 @@
 import {
   type BIP122_REQUESTS,
+  BIP122_QUERY_METHODS,
   BIP122_RESPONSES,
   BIP122_SIGNING_METHODS,
+  bip122GetAccountAddressesSchema,
   bip122SignMessageLegacySchema,
   bip122SignMessageSchema,
   bip122SignPsbtSchema,
 } from "@/data/methods/BIP122.methods";
+import { fetchBip122Addresses } from "@/utils/bip122";
 import { btcTransactionSchema, convertBtcToLiveTX } from "@/utils/converters";
 import { getAccountWithAddressAndChainId } from "@/utils/generic";
 import { isPSBTSupportEnabled } from "@/utils/helper.util";
@@ -214,6 +217,28 @@ export async function handleBIP122Request(
           throw error;
         }
       }
+      break;
+    }
+    case BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES: {
+      const params = bip122GetAccountAddressesSchema.parse(request.params);
+
+      const account = getAccountWithAddressAndChainId(
+        accounts,
+        params.account,
+        chainId,
+      );
+
+      if (!account) {
+        await rejectRequest(walletkit, topic, id, Errors.userDecline);
+        break;
+      }
+
+      const result = await fetchBip122Addresses(
+        account,
+        client,
+        params.intentions,
+      );
+      await acceptRequest(walletkit, topic, id, result);
       break;
     }
     default:

--- a/src/hooks/requestHandlers/BIP122.ts
+++ b/src/hooks/requestHandlers/BIP122.ts
@@ -39,9 +39,10 @@ export async function handleBIP122Request(
     client: WalletAPIClient;
     walletkit: IWalletKit;
     walletCapabilities?: string[];
+    sessionAddress?: string;
   },
 ) {
-  const { accounts, client, walletkit, walletCapabilities = [] } = context;
+  const { accounts, client, walletkit, walletCapabilities = [], sessionAddress } = context;
 
   switch (request.method) {
     case BIP122_SIGNING_METHODS.BIP122_SIGN_MESSAGE_LEGACY: {
@@ -220,24 +221,26 @@ export async function handleBIP122Request(
       break;
     }
     case BIP122_QUERY_METHODS.BIP122_GET_ACCOUNT_ADDRESSES: {
-      const params = bip122GetAccountAddressesSchema.parse(request.params);
+      // Some adapters (e.g. AppKit bitcoin adapter) send getAccountAddresses
+      // without params. Fall back to the selected account for the session.
+      const params = request.params != null
+        ? bip122GetAccountAddressesSchema.parse(request.params)
+        : undefined;
 
-      const account = getAccountWithAddressAndChainId(
-        accounts,
-        params.account,
-        chainId,
-      );
+      const selectedAddress = params?.account ?? sessionAddress;
+
+      const account = selectedAddress
+        ? getAccountWithAddressAndChainId(accounts, selectedAddress, chainId)
+        : undefined;
+
+      const intentions = params?.intentions;
 
       if (!account) {
         await rejectRequest(walletkit, topic, id, Errors.userDecline);
         break;
       }
 
-      const result = await fetchBip122Addresses(
-        account,
-        client,
-        params.intentions,
-      );
+      const result = await fetchBip122Addresses(account, client, intentions);
       await acceptRequest(walletkit, topic, id, result);
       break;
     }

--- a/src/hooks/requestHandlers/solanaHandlers/signMessage.test.ts
+++ b/src/hooks/requestHandlers/solanaHandlers/signMessage.test.ts
@@ -8,7 +8,11 @@ import { vi } from "vitest";
 import * as utils from "../utils";
 import { signMessage } from "./signMessage";
 
-vi.mock("../../../utils");
+vi.mock("../utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  acceptRequest: vi.fn(),
+  rejectRequest: vi.fn(),
+}));
 vi.mock("@/utils/generic");
 
 describe("Testing sign message on Solana", () => {

--- a/src/hooks/useProposal/useProposal.ts
+++ b/src/hooks/useProposal/useProposal.ts
@@ -104,7 +104,7 @@ export function useProposal(
         search: ({ uri: _, ...search }) => search,
       });
 
-      // Emit bip122_addressesChanged immediately after approval for all BIP122 accounts
+      // Emit bip122_addressesChanged immediately after approval once per BIP122 chain
       // per Reown spec: https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc#bip122_addresseschanged
       const bip122Namespace = session.namespaces.bip122;
       if (bip122Namespace?.events.includes("bip122_addressesChanged")) {

--- a/src/hooks/useProposal/useProposal.ts
+++ b/src/hooks/useProposal/useProposal.ts
@@ -1,32 +1,33 @@
-import { useCallback, useState } from "react";
-import { getErrorMessage } from "@/utils/helper.util";
-import { getAccountWithAddressAndChainId } from "@/utils/generic";
+import useAccounts, { queryKey as accountsQueryKey } from "@/hooks/useAccounts";
 import useAnalytics from "@/hooks/useAnalytics";
+import { walletAPIClientAtom } from "@/store/wallet-api.store";
+import {
+  showBackToBrowserModalAtom,
+  walletKitAtom,
+} from "@/store/walletKit.store";
+import { OneClickAuthPayload } from "@/types/types";
+import { fetchBip122Addresses } from "@/utils/bip122";
+import { getAccountWithAddressAndChainId } from "@/utils/generic";
+import { getErrorMessage } from "@/utils/helper.util";
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { ProposalTypes } from "@walletconnect/types";
 import {
   buildApprovedNamespaces,
   buildAuthObject,
   populateAuthPayload,
 } from "@walletconnect/utils";
-import { useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  showBackToBrowserModalAtom,
-  walletKitAtom,
-} from "@/store/walletKit.store";
 import { useAtomValue, useSetAtom } from "jotai";
-import useAccounts, { queryKey as accountsQueryKey } from "@/hooks/useAccounts";
-import { walletAPIClientAtom } from "@/store/wallet-api.store";
+import { enqueueSnackbar } from "notistack";
+import { useCallback, useState } from "react";
+import { sortedRecentConnectionAppsAtom } from "../../store/recentConnectionAppsAtom";
+import { formatMessage } from "../requestHandlers/utils";
+import { queryKey as pendingProposalsQueryKey } from "../usePendingProposals";
 import {
   queryKey as sessionsQueryKey,
   useQueryFn as useSessionsQueryFn,
 } from "../useSessions";
-import { queryKey as pendingProposalsQueryKey } from "../usePendingProposals";
-import { ProposalTypes } from "@walletconnect/types";
-import { OneClickAuthPayload } from "@/types/types";
-import { enqueueSnackbar } from "notistack";
-import { sortedRecentConnectionAppsAtom } from "../../store/recentConnectionAppsAtom";
 import { useSupportedNamespaces } from "../useSupportedNamespaces";
-import { formatMessage } from "../requestHandlers/utils";
 
 export function useProposal(
   proposal: ProposalTypes.Struct,
@@ -103,6 +104,33 @@ export function useProposal(
         search: ({ uri: _, ...search }) => search,
       });
 
+      // Emit bip122_addressesChanged immediately after approval for all BIP122 accounts
+      // per Reown spec: https://docs.reown.com/advanced/multichain/rpc-reference/bitcoin-rpc#bip122_addresseschanged
+      const bip122Namespace = session.namespaces.bip122;
+      if (bip122Namespace?.events.includes("bip122_addressesChanged")) {
+        const emittedChains = new Set<string>();
+        for (const caipAccount of bip122Namespace.accounts) {
+          const [namespace, chainRef, address] = caipAccount.split(":");
+          const chainId = `${namespace}:${chainRef}`;
+          if (emittedChains.has(chainId)) continue;
+          const account = accounts.data.find((a) => a.address === address);
+          if (account) {
+            const addressesData = await fetchBip122Addresses(account, client, [
+              "payment",
+            ]);
+            await walletKit.emitSessionEvent({
+              topic: session.topic,
+              event: {
+                name: "bip122_addressesChanged",
+                data: addressesData,
+              },
+              chainId,
+            });
+            emittedChains.add(chainId);
+          }
+        }
+      }
+
       redirectToDapp();
     } catch (error) {
       enqueueSnackbar(getErrorMessage(error), {
@@ -128,6 +156,8 @@ export function useProposal(
     sessionsQueryFn,
     addAppToLastConnectionApps,
     navigate,
+    accounts.data,
+    client,
   ]);
 
   const approveSessionAuthenticate = useCallback(async () => {

--- a/src/hooks/useSessionDetails.ts
+++ b/src/hooks/useSessionDetails.ts
@@ -5,6 +5,7 @@ import {
   showBackToBrowserModalAtom,
   walletKitAtom,
 } from "@/store/walletKit.store";
+import { fetchBip122Addresses } from "@/utils/bip122";
 import {
   getCurrencyByChainId,
   getErrorMessage,
@@ -260,11 +261,14 @@ export function useSessionDetails(session: SessionTypes.Struct) {
       if (
         session.namespaces[namespace].events.includes("bip122_addressesChanged")
       ) {
+        const addressesData = await fetchBip122Addresses(account, client, [
+          "payment",
+        ]);
         await walletKit.emitSessionEvent({
           topic: session.topic,
           event: {
             name: "bip122_addressesChanged",
-            data: chainValue,
+            data: addressesData,
           },
           chainId,
         });
@@ -294,7 +298,7 @@ export function useSessionDetails(session: SessionTypes.Struct) {
         queryFn: sessionsQueryFn,
       });
     },
-    [queryClient, session, sessionsQueryFn, setShowModal, walletKit],
+    [client, queryClient, session, sessionsQueryFn, setShowModal, walletKit],
   );
 
   function getAccountsFromAddresses(addresses: string[], accounts: Account[]) {

--- a/src/hooks/useSupportedNamespaces.ts
+++ b/src/hooks/useSupportedNamespaces.ts
@@ -1,4 +1,7 @@
-import { BIP122_SIGNING_METHODS } from "@/data/methods/BIP122.methods";
+import {
+  BIP122_QUERY_METHODS,
+  BIP122_SIGNING_METHODS,
+} from "@/data/methods/BIP122.methods";
 import { EIP155_SIGNING_METHODS } from "@/data/methods/EIP155Data.methods";
 import { RIPPLE_SIGNING_METHODS } from "@/data/methods/Ripple.methods";
 import { SOLANA_SIGNING_METHODS } from "@/data/methods/Solana.methods";
@@ -134,6 +137,7 @@ export function useSupportedNamespaces(
       const supportedMethods: string[] = [
         ...Object.values(WALLET_METHODS),
         ...Object.values(BIP122_SIGNING_METHODS),
+        ...Object.values(BIP122_QUERY_METHODS),
       ];
 
       const methods = [

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -211,6 +211,14 @@ export default function useWalletConnect() {
               walletKit,
             );
           } else if (isBIP122Chain(chainId, request)) {
+            const session =
+              walletKit.engine.signClient.session.get(topic);
+            const bip122Accounts =
+              session?.namespaces.bip122?.accounts ?? [];
+            const sessionAddress = bip122Accounts
+              .find((a) => a.startsWith(chainId + ":"))
+              ?.split(":")[2];
+
             await handleBIP122Request(
               request,
               topic,
@@ -221,6 +229,7 @@ export default function useWalletConnect() {
                 client,
                 walletkit: walletKit,
                 walletCapabilities,
+                sessionAddress,
               },
             );
           } else if (

--- a/src/tests/hook-test.utils.tsx
+++ b/src/tests/hook-test.utils.tsx
@@ -1,0 +1,23 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Provider, createStore } from "jotai";
+import { Suspense, type ReactNode } from "react";
+
+export type TestStore = ReturnType<typeof createStore>;
+
+export function createHookWrapper(store: TestStore) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <Suspense fallback={null}>{children}</Suspense>
+        </Provider>
+      </QueryClientProvider>
+    );
+  };
+}

--- a/src/utils/bip122.ts
+++ b/src/utils/bip122.ts
@@ -1,0 +1,21 @@
+import type { BIP122AccountAddress } from "@/data/methods/BIP122.methods";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+
+export async function fetchBip122Addresses(
+  account: Account,
+  client: WalletAPIClient,
+  intentions?: string[],
+): Promise<BIP122AccountAddress[]> {
+  try {
+    const entries = await client.bitcoin.getAddresses(
+      account.id,
+      intentions as ("payment" | "ordinal")[] | undefined,
+    );
+    if (entries.length > 0) {
+      return entries;
+    }
+  } catch {
+    // fall through to default
+  }
+  return [{ address: account.address }];
+}


### PR DESCRIPTION
### 📝 Description

- Add BIP122_QUERY_METHODS and bip122GetAccountAddressesSchema
- Handle getAccountAddresses in the BIP122 request handler, falling back to the account address when getAddresses is unavailable or returns empty
- Extract fetchBip122Addresses shared utility to avoid duplication across the request handler, useProposal, and useSessionDetails
- Emit bip122_addressesChanged immediately after session approval
- Replace chainValue with actual address data in the bip122_addressesChanged event emitted on account switch
- Register getAccountAddresses as a supported BIP122 method

### ❓ Context

- **Linked resource(s)**: [LIVE-18131] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-18131]: https://ledgerhq.atlassian.net/browse/LIVE-18131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ