### PR TITLE
refactor: split EIP155 request handlers and add coverage

### DIFF
--- a/src/hooks/requestHandlers/EIP155.test.ts
+++ b/src/hooks/requestHandlers/EIP155.test.ts
@@ -1,0 +1,192 @@
+import {
+  EIP155_SIGNING_METHODS,
+  type EIP155_REQUESTS,
+} from "@/data/methods/EIP155Data.methods";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleEIP155Request } from "./EIP155";
+import * as sendTransactionModule from "./eip155Handlers/sendTransaction";
+import * as signMessageModule from "./eip155Handlers/signMessage";
+import * as signTypedDataModule from "./eip155Handlers/signTypedData";
+import * as utils from "./utils";
+
+vi.mock("./utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./utils")>()),
+  rejectRequest: vi.fn(),
+}));
+
+describe("Testing EIP155 request handler mapping", () => {
+  const walletAPIClient = {} as WalletAPIClient;
+  const walletKit = {} as IWalletKit;
+  const topic = "topic";
+  const id = 0;
+  const chainId = "eip155:1";
+  const accounts: Account[] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call sign message when request method is eth_sign", async () => {
+    const request: EIP155_REQUESTS = {
+      method: EIP155_SIGNING_METHODS.ETH_SIGN,
+      params: ["0x123", "0x68656c6c6f"],
+    };
+
+    const signMessageSpy = vi.spyOn(signMessageModule, "signMessage");
+    signMessageSpy.mockImplementationOnce(() => Promise.resolve());
+
+    await handleEIP155Request(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(signMessageSpy).toHaveBeenCalledTimes(1);
+    expect(signMessageSpy).toHaveBeenCalledWith(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+  });
+
+  it("should call sign message when request method is personal_sign", async () => {
+    const request: EIP155_REQUESTS = {
+      method: EIP155_SIGNING_METHODS.PERSONAL_SIGN,
+      params: ["0x68656c6c6f", "0x123"],
+    };
+
+    const signMessageSpy = vi.spyOn(signMessageModule, "signMessage");
+    signMessageSpy.mockImplementationOnce(() => Promise.resolve());
+
+    await handleEIP155Request(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(signMessageSpy).toHaveBeenCalledTimes(1);
+    expect(signMessageSpy).toHaveBeenCalledWith(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+  });
+
+  it.each([
+    EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA,
+    EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3,
+    EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4,
+  ])("should call sign typed data when request method is %s", async (method) => {
+    const request: EIP155_REQUESTS = {
+      method,
+      params: ["0x123", '{"hello":"world"}'],
+    };
+
+    const signTypedDataSpy = vi.spyOn(signTypedDataModule, "signTypedData");
+    signTypedDataSpy.mockImplementationOnce(() => Promise.resolve());
+
+    await handleEIP155Request(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(signTypedDataSpy).toHaveBeenCalledTimes(1);
+    expect(signTypedDataSpy).toHaveBeenCalledWith(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+  });
+
+  it.each([
+    EIP155_SIGNING_METHODS.ETH_SIGN_TRANSACTION,
+    EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION,
+  ])("should call send transaction when request method is %s", async (method) => {
+    const request: EIP155_REQUESTS = {
+      method,
+      params: [
+        {
+          from: "0x123",
+        },
+      ],
+    };
+
+    const sendTransactionSpy = vi.spyOn(
+      sendTransactionModule,
+      "sendTransaction",
+    );
+    sendTransactionSpy.mockImplementationOnce(() => Promise.resolve());
+
+    await handleEIP155Request(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sendTransactionSpy).toHaveBeenCalledTimes(1);
+    expect(sendTransactionSpy).toHaveBeenCalledWith(
+      request,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+  });
+
+  it("should reject unsupported methods with code 5101", async () => {
+    await handleEIP155Request(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_ACCOUNTS,
+        params: [],
+      } as unknown as never,
+      topic,
+      id,
+      chainId,
+      accounts,
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.unsupportedMethods,
+      5101,
+    );
+  });
+});

--- a/src/hooks/requestHandlers/EIP155.ts
+++ b/src/hooks/requestHandlers/EIP155.ts
@@ -1,22 +1,13 @@
 import {
-  EIP155_RESPONSES,
   EIP155_SIGNING_METHODS,
-  ethSendTransactionSchema,
-  ethSignSchema,
   type EIP155_REQUESTS,
 } from "@/data/methods/EIP155Data.methods";
-import { convertEthToLiveTX } from "@/utils/converters";
-import { stripHexPrefix } from "@/utils/currencyFormatter/helpers";
-import { getAccountWithAddressAndChainId } from "@/utils/generic";
 import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
 import type { IWalletKit } from "@reown/walletkit";
-import {
-  acceptRequest,
-  Errors,
-  formatMessage,
-  isCanceledError,
-  rejectRequest,
-} from "./utils";
+import { sendTransaction } from "./eip155Handlers/sendTransaction";
+import { signMessage } from "./eip155Handlers/signMessage";
+import { signTypedData } from "./eip155Handlers/signTypedData";
+import { Errors, rejectRequest } from "./utils";
 
 export async function handleEIP155Request(
   request: EIP155_REQUESTS,
@@ -29,108 +20,34 @@ export async function handleEIP155Request(
 ) {
   switch (request.method) {
     case EIP155_SIGNING_METHODS.ETH_SIGN:
-    case EIP155_SIGNING_METHODS.PERSONAL_SIGN: {
-      const isPersonalSign =
-        request.method === EIP155_SIGNING_METHODS.PERSONAL_SIGN;
-
-      const params = ethSignSchema.parse(request.params);
-      const address = isPersonalSign ? params[1] : params[0];
-      const message = isPersonalSign ? params[0] : params[1];
-
-      const accountSign = getAccountWithAddressAndChainId(
-        accounts,
-        address,
-        chainId,
-      );
-      if (accountSign) {
-        try {
-          const signedMessage = await client.message.sign(
-            accountSign.id,
-            Buffer.from(stripHexPrefix(message), "hex"),
-          );
-
-          const result: EIP155_RESPONSES[typeof request.method] =
-            formatMessage(signedMessage);
-
-          await acceptRequest(walletKit, topic, id, result);
-        } catch (error) {
-          if (isCanceledError(error)) {
-            await rejectRequest(walletKit, topic, id, Errors.userDecline);
-          } else {
-            throw error;
-          }
-        }
-      } else {
-        await rejectRequest(walletKit, topic, id, Errors.userDecline);
-      }
+    case EIP155_SIGNING_METHODS.PERSONAL_SIGN:
+      await signMessage(request, topic, id, chainId, accounts, client, walletKit);
       break;
-    }
     case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA:
     case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3:
-    case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4: {
-      const params = ethSignSchema.parse(request.params);
-      const address = params[0];
-      const message = stripHexPrefix(params[1]);
-
-      const accountSignTyped = getAccountWithAddressAndChainId(
-        accounts,
-        address,
+    case EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4:
+      await signTypedData(
+        request,
+        topic,
+        id,
         chainId,
+        accounts,
+        client,
+        walletKit,
       );
-      if (accountSignTyped) {
-        try {
-          const signedMessage = await client.message.sign(
-            accountSignTyped.id,
-            Buffer.from(message),
-          );
-
-          const result: EIP155_RESPONSES[typeof request.method] =
-            formatMessage(signedMessage);
-
-          await acceptRequest(walletKit, topic, id, result);
-        } catch (error) {
-          if (isCanceledError(error)) {
-            await rejectRequest(walletKit, topic, id, Errors.msgDecline);
-          } else {
-            throw error;
-          }
-        }
-      } else {
-        await rejectRequest(walletKit, topic, id, Errors.msgDecline);
-      }
       break;
-    }
     case EIP155_SIGNING_METHODS.ETH_SIGN_TRANSACTION:
-    case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION: {
-      const ethTx = ethSendTransactionSchema.parse(request.params)[0];
-      const accountTX = getAccountWithAddressAndChainId(
-        accounts,
-        ethTx.from,
+    case EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION:
+      await sendTransaction(
+        request,
+        topic,
+        id,
         chainId,
+        accounts,
+        client,
+        walletKit,
       );
-      if (accountTX) {
-        try {
-          const liveTx = convertEthToLiveTX(ethTx);
-          const hash = await client.transaction.signAndBroadcast(
-            accountTX.id,
-            liveTx,
-          );
-
-          const result: EIP155_RESPONSES[typeof request.method] = hash;
-
-          await acceptRequest(walletKit, topic, id, result);
-        } catch (error) {
-          if (isCanceledError(error)) {
-            await rejectRequest(walletKit, topic, id, Errors.txDeclined);
-          } else {
-            throw error;
-          }
-        }
-      } else {
-        await rejectRequest(walletKit, topic, id, Errors.txDeclined);
-      }
       break;
-    }
     default:
       await rejectRequest(
         walletKit,

--- a/src/hooks/requestHandlers/eip155Handlers/sendTransaction.test.ts
+++ b/src/hooks/requestHandlers/eip155Handlers/sendTransaction.test.ts
@@ -1,0 +1,144 @@
+import { EIP155_SIGNING_METHODS } from "@/data/methods/EIP155Data.methods";
+import * as utils from "@/hooks/requestHandlers/utils";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendTransaction } from "./sendTransaction";
+
+vi.mock("@/hooks/requestHandlers/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/requestHandlers/utils")>()),
+  acceptRequest: vi.fn(),
+  rejectRequest: vi.fn(),
+}));
+
+describe("Testing send transaction on EIP155", () => {
+  const account = {
+    id: "account-id",
+    address: "0xAbC123",
+    currency: "ethereum",
+  } as Account;
+  const walletKit = {} as IWalletKit;
+  const topic = "topic";
+  const id = 0;
+  const chainId = "eip155:1";
+  const params = [
+    {
+      from: account.address,
+      to: "0x0000000000000000000000000000000000000001",
+      value: "0x1",
+      gas: "0x5208",
+      gasPrice: "0x3b9aca00",
+      nonce: "0x0",
+      data: "0x",
+    },
+  ] as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    EIP155_SIGNING_METHODS.ETH_SIGN_TRANSACTION,
+    EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION,
+  ])("should sign and accept %s requests", async (method) => {
+    const signAndBroadcast = vi.fn(() => Promise.resolve("0xhash"));
+    const walletAPIClient = {
+      transaction: {
+        signAndBroadcast,
+      },
+    } as unknown as WalletAPIClient;
+
+    await sendTransaction(
+      {
+        method,
+        params: [...params],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(signAndBroadcast).toHaveBeenCalledTimes(1);
+    expect(signAndBroadcast).toHaveBeenCalledWith(
+      account.id,
+      expect.any(Object),
+    );
+    expect(utils.acceptRequest).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      "0xhash",
+    );
+    expect(utils.rejectRequest).not.toHaveBeenCalled();
+  });
+
+  it("should reject the request when no matching account is found", async () => {
+    const signAndBroadcast = vi.fn();
+    const walletAPIClient = {
+      transaction: {
+        signAndBroadcast,
+      },
+    } as unknown as WalletAPIClient;
+
+    await sendTransaction(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION,
+        params: [...params],
+      },
+      topic,
+      id,
+      chainId,
+      [],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(signAndBroadcast).not.toHaveBeenCalled();
+    expect(utils.acceptRequest).not.toHaveBeenCalled();
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.txDeclined,
+    );
+  });
+
+  it("should reject the request when the user cancels the transaction", async () => {
+    const signAndBroadcast = vi.fn(() =>
+      Promise.reject(new Error("User cancelled")),
+    );
+    const walletAPIClient = {
+      transaction: {
+        signAndBroadcast,
+      },
+    } as unknown as WalletAPIClient;
+
+    await sendTransaction(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION,
+        params: [...params],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(signAndBroadcast).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).not.toHaveBeenCalled();
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.txDeclined,
+    );
+  });
+});

--- a/src/hooks/requestHandlers/eip155Handlers/sendTransaction.ts
+++ b/src/hooks/requestHandlers/eip155Handlers/sendTransaction.ts
@@ -1,0 +1,62 @@
+import {
+  EIP155_RESPONSES,
+  EIP155_SIGNING_METHODS,
+  ethSendTransactionSchema,
+  type EIP155_REQUESTS,
+} from "@/data/methods/EIP155Data.methods";
+import {
+  acceptRequest,
+  Errors,
+  isCanceledError,
+  rejectRequest,
+} from "@/hooks/requestHandlers/utils";
+import { convertEthToLiveTX } from "@/utils/converters";
+import { getAccountWithAddressAndChainId } from "@/utils/generic";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+
+export async function sendTransaction(
+  request: EIP155_REQUESTS,
+  topic: string,
+  id: number,
+  chainId: string,
+  accounts: Account[],
+  client: WalletAPIClient,
+  walletKit: IWalletKit,
+) {
+  if (
+    request.method !== EIP155_SIGNING_METHODS.ETH_SIGN_TRANSACTION &&
+    request.method !== EIP155_SIGNING_METHODS.ETH_SEND_TRANSACTION
+  ) {
+    throw new Error(
+      `Method ${request.method} from request can not be used to send transaction`,
+    );
+  }
+
+  const ethTx = ethSendTransactionSchema.parse(request.params)[0];
+  const account = getAccountWithAddressAndChainId(
+    accounts,
+    ethTx.from,
+    chainId,
+  );
+
+  if (!account) {
+    await rejectRequest(walletKit, topic, id, Errors.txDeclined);
+    return;
+  }
+
+  try {
+    const liveTx = convertEthToLiveTX(ethTx);
+    const hash = await client.transaction.signAndBroadcast(account.id, liveTx);
+
+    const result: EIP155_RESPONSES[typeof request.method] = hash;
+
+    await acceptRequest(walletKit, topic, id, result);
+  } catch (error) {
+    if (isCanceledError(error)) {
+      await rejectRequest(walletKit, topic, id, Errors.txDeclined);
+    } else {
+      throw error;
+    }
+  }
+}

--- a/src/hooks/requestHandlers/eip155Handlers/signMessage.test.ts
+++ b/src/hooks/requestHandlers/eip155Handlers/signMessage.test.ts
@@ -1,0 +1,163 @@
+import { EIP155_SIGNING_METHODS } from "@/data/methods/EIP155Data.methods";
+import * as utils from "@/hooks/requestHandlers/utils";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signMessage } from "./signMessage";
+
+vi.mock("@/hooks/requestHandlers/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/requestHandlers/utils")>()),
+  acceptRequest: vi.fn(),
+  rejectRequest: vi.fn(),
+}));
+
+describe("Testing sign message on EIP155", () => {
+  const account = {
+    id: "account-id",
+    address: "0xAbC123",
+    currency: "ethereum",
+  } as Account;
+  const walletKit = {} as IWalletKit;
+  const topic = "topic";
+  const id = 0;
+  const chainId = "eip155:1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should sign and accept eth_sign requests", async () => {
+    const sign = vi.fn(() => Promise.resolve(Buffer.from("abcd", "hex")));
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signMessage(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SIGN,
+        params: [account.address, "0x68656c6c6f"],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(sign).toHaveBeenCalledWith(
+      account.id,
+      Buffer.from("68656c6c6f", "hex"),
+    );
+    expect(utils.acceptRequest).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      "0xabcd",
+    );
+    expect(utils.rejectRequest).not.toHaveBeenCalled();
+  });
+
+  it("should sign and accept personal_sign requests with the wallet address in the second param", async () => {
+    const sign = vi.fn(() => Promise.resolve(Buffer.from("beef", "hex")));
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signMessage(
+      {
+        method: EIP155_SIGNING_METHODS.PERSONAL_SIGN,
+        params: ["0x68656c6c6f", account.address],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(sign).toHaveBeenCalledWith(
+      account.id,
+      Buffer.from("68656c6c6f", "hex"),
+    );
+    expect(utils.acceptRequest).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      "0xbeef",
+    );
+  });
+
+  it("should reject the request when no matching account is found", async () => {
+    const sign = vi.fn();
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signMessage(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SIGN,
+        params: [account.address, "0x68656c6c6f"],
+      },
+      topic,
+      id,
+      chainId,
+      [],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).not.toHaveBeenCalled();
+    expect(utils.acceptRequest).not.toHaveBeenCalled();
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.userDecline,
+    );
+  });
+
+  it("should reject the request when the user cancels signing", async () => {
+    const sign = vi.fn(() => Promise.reject(new Error("User cancelled")));
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signMessage(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SIGN,
+        params: [account.address, "0x68656c6c6f"],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).not.toHaveBeenCalled();
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.userDecline,
+    );
+  });
+});

--- a/src/hooks/requestHandlers/eip155Handlers/signMessage.ts
+++ b/src/hooks/requestHandlers/eip155Handlers/signMessage.ts
@@ -1,0 +1,65 @@
+import {
+  EIP155_RESPONSES,
+  EIP155_SIGNING_METHODS,
+  ethSignSchema,
+  type EIP155_REQUESTS,
+} from "@/data/methods/EIP155Data.methods";
+import {
+  acceptRequest,
+  Errors,
+  formatMessage,
+  isCanceledError,
+  rejectRequest,
+} from "@/hooks/requestHandlers/utils";
+import { stripHexPrefix } from "@/utils/currencyFormatter/helpers";
+import { getAccountWithAddressAndChainId } from "@/utils/generic";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+
+export async function signMessage(
+  request: EIP155_REQUESTS,
+  topic: string,
+  id: number,
+  chainId: string,
+  accounts: Account[],
+  client: WalletAPIClient,
+  walletKit: IWalletKit,
+) {
+  if (
+    request.method !== EIP155_SIGNING_METHODS.ETH_SIGN &&
+    request.method !== EIP155_SIGNING_METHODS.PERSONAL_SIGN
+  ) {
+    throw new Error(
+      `Method ${request.method} from request can not be used to sign message`,
+    );
+  }
+
+  const isPersonalSign = request.method === EIP155_SIGNING_METHODS.PERSONAL_SIGN;
+  const params = ethSignSchema.parse(request.params);
+  const address = isPersonalSign ? params[1] : params[0];
+  const message = isPersonalSign ? params[0] : params[1];
+  const account = getAccountWithAddressAndChainId(accounts, address, chainId);
+
+  if (!account) {
+    await rejectRequest(walletKit, topic, id, Errors.userDecline);
+    return;
+  }
+
+  try {
+    const signedMessage = await client.message.sign(
+      account.id,
+      Buffer.from(stripHexPrefix(message), "hex"),
+    );
+
+    const result: EIP155_RESPONSES[typeof request.method] =
+      formatMessage(signedMessage);
+
+    await acceptRequest(walletKit, topic, id, result);
+  } catch (error) {
+    if (isCanceledError(error)) {
+      await rejectRequest(walletKit, topic, id, Errors.userDecline);
+    } else {
+      throw error;
+    }
+  }
+}

--- a/src/hooks/requestHandlers/eip155Handlers/signTypedData.test.ts
+++ b/src/hooks/requestHandlers/eip155Handlers/signTypedData.test.ts
@@ -1,0 +1,133 @@
+import { EIP155_SIGNING_METHODS } from "@/data/methods/EIP155Data.methods";
+import * as utils from "@/hooks/requestHandlers/utils";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signTypedData } from "./signTypedData";
+
+vi.mock("@/hooks/requestHandlers/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/requestHandlers/utils")>()),
+  acceptRequest: vi.fn(),
+  rejectRequest: vi.fn(),
+}));
+
+describe("Testing sign typed data on EIP155", () => {
+  const account = {
+    id: "account-id",
+    address: "0xAbC123",
+    currency: "ethereum",
+  } as Account;
+  const walletKit = {} as IWalletKit;
+  const topic = "topic";
+  const id = 0;
+  const chainId = "eip155:1";
+  const message = '{"hello":"walletconnect"}';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA,
+    EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3,
+    EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4,
+  ])("should sign and accept %s requests", async (method) => {
+    const sign = vi.fn(() => Promise.resolve(Buffer.from("abcd", "hex")));
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signTypedData(
+      {
+        method,
+        params: [account.address, message],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(sign).toHaveBeenCalledWith(
+      account.id,
+      Buffer.from(message),
+    );
+    expect(utils.acceptRequest).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      "0xabcd",
+    );
+    expect(utils.rejectRequest).not.toHaveBeenCalled();
+  });
+
+  it("should reject the request when no matching account is found", async () => {
+    const sign = vi.fn();
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signTypedData(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4,
+        params: [account.address, message],
+      },
+      topic,
+      id,
+      chainId,
+      [],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).not.toHaveBeenCalled();
+    expect(utils.acceptRequest).not.toHaveBeenCalled();
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.msgDecline,
+    );
+  });
+
+  it("should reject the request when the user cancels signing", async () => {
+    const sign = vi.fn(() => Promise.reject(new Error("Canceled by user")));
+    const walletAPIClient = {
+      message: {
+        sign,
+      },
+    } as unknown as WalletAPIClient;
+
+    await signTypedData(
+      {
+        method: EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4,
+        params: [account.address, message],
+      },
+      topic,
+      id,
+      chainId,
+      [account],
+      walletAPIClient,
+      walletKit,
+    );
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(utils.acceptRequest).not.toHaveBeenCalled();
+    expect(utils.rejectRequest).toHaveBeenCalledTimes(1);
+    expect(utils.rejectRequest).toHaveBeenCalledWith(
+      walletKit,
+      topic,
+      id,
+      utils.Errors.msgDecline,
+    );
+  });
+});

--- a/src/hooks/requestHandlers/eip155Handlers/signTypedData.ts
+++ b/src/hooks/requestHandlers/eip155Handlers/signTypedData.ts
@@ -1,0 +1,65 @@
+import {
+  EIP155_RESPONSES,
+  EIP155_SIGNING_METHODS,
+  ethSignSchema,
+  type EIP155_REQUESTS,
+} from "@/data/methods/EIP155Data.methods";
+import {
+  acceptRequest,
+  Errors,
+  formatMessage,
+  isCanceledError,
+  rejectRequest,
+} from "@/hooks/requestHandlers/utils";
+import { stripHexPrefix } from "@/utils/currencyFormatter/helpers";
+import { getAccountWithAddressAndChainId } from "@/utils/generic";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+
+export async function signTypedData(
+  request: EIP155_REQUESTS,
+  topic: string,
+  id: number,
+  chainId: string,
+  accounts: Account[],
+  client: WalletAPIClient,
+  walletKit: IWalletKit,
+) {
+  if (
+    request.method !== EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA &&
+    request.method !== EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V3 &&
+    request.method !== EIP155_SIGNING_METHODS.ETH_SIGN_TYPED_DATA_V4
+  ) {
+    throw new Error(
+      `Method ${request.method} from request can not be used to sign typed data`,
+    );
+  }
+
+  const params = ethSignSchema.parse(request.params);
+  const address = params[0];
+  const message = stripHexPrefix(params[1]);
+  const account = getAccountWithAddressAndChainId(accounts, address, chainId);
+
+  if (!account) {
+    await rejectRequest(walletKit, topic, id, Errors.msgDecline);
+    return;
+  }
+
+  try {
+    const signedMessage = await client.message.sign(
+      account.id,
+      Buffer.from(message),
+    );
+
+    const result: EIP155_RESPONSES[typeof request.method] =
+      formatMessage(signedMessage);
+
+    await acceptRequest(walletKit, topic, id, result);
+  } catch (error) {
+    if (isCanceledError(error)) {
+      await rejectRequest(walletKit, topic, id, Errors.msgDecline);
+    } else {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION

### 📝 Description

Mirror the Solana request-handler structure by extracting EIP155 signing and transaction flows into dedicated modules. Add focused router and handler tests.

### ❓ Context

- **Linked resource(s)**: []

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->
