### PR TITLE
fix(xrpl): keep extra tx_json fields for xrpl tx

### DIFF
--- a/src/data/__tests__/Ripple.methods.zod-behavior.test.ts
+++ b/src/data/__tests__/Ripple.methods.zod-behavior.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { rippleSignTransactionSchema } from "../methods/Ripple.methods";
+
+const input = {
+  tx_json: {
+    Account: "r...",
+    TransactionType: "Payment",
+    Fee: "12",
+  },
+};
+
+describe("Ripple Zod schema unknown keys behavior", () => {
+  it("keeps unknown tx_json fields from the current parsed result", () => {
+    const parsed = rippleSignTransactionSchema.parse(input);
+
+    expect(parsed.tx_json).toEqual(input.tx_json);
+  });
+
+  it("shows why a plain z.object would strip unknown tx_json fields", () => {
+    const schemaWithPlainObject = z.strictObject({
+      tx_json: z.object({
+        Account: z.string(),
+      }),
+    });
+
+    const parsed = schemaWithPlainObject.parse(input);
+
+    expect(parsed.tx_json).toEqual({
+      Account: "r...",
+    });
+  });
+});

--- a/src/data/methods/Ripple.methods.ts
+++ b/src/data/methods/Ripple.methods.ts
@@ -12,7 +12,7 @@ export const rippleSignTransactionSchema = z.strictObject({
   // we only check that Account exists here
   // as it's the only mandatory field to find the account
   // the rest of the tx_json is not validated here
-  tx_json: z.object({
+  tx_json: z.looseObject({
     Account: z.string(),
   }),
   autofill: z.boolean().optional(),


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Fixes the XRPL WalletConnect signing flow by preserving the full `tx_json` payload when parsing `xrpl_signTransaction` requests. The previous Zod schema accepted extra XRPL fields but stripped them from the parsed output, so we could receive an incomplete raw transaction before `transaction.signRaw`.

This switches the XRPL transaction schema to `z.looseObject(...)` and adds a focused test to ensure fields like `TransactionType` and `Fee` are kept.

### ❓ Context

- **[Linked resource](https://ledgerhq.atlassian.net/browse/LIVE-30352)(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ