### PR TITLE
feat: add Somnia network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ and is intended to be integrated within ledger products, enabling users to seaml
 | Monad             | ✅          | ✅                 |                    |
 | ADI Chain         | ✅          | -                  |                    |
 | Sei EVM           | ✅          | -                  | -                  |
+| Somnia            | ✅          | -                  | -                  |
 
 ## Hosting
 

--- a/localManifest.json
+++ b/localManifest.json
@@ -37,6 +37,7 @@
     "base_sepolia",
     "ripple",
     "sei_evm",
+    "somnia",
     "ethereum_holesky"
   ],
   "content": {

--- a/src/data/__tests__/networkConfig.test.ts
+++ b/src/data/__tests__/networkConfig.test.ts
@@ -77,6 +77,15 @@ describe("SUPPORTED_NETWORK", () => {
     expect(seiEvm?.namespace).toBe("eip155:1329");
     expect(seiEvm?.ticker).toBe("SEI");
   });
+
+  it("contains Somnia", () => {
+    const somnia: Network | undefined = SUPPORTED_NETWORK.somnia;
+
+    expect(somnia?.displayName).toBe("Somnia");
+    expect(somnia?.chainId).toBe(5031);
+    expect(somnia?.namespace).toBe("eip155:5031");
+    expect(somnia?.ticker).toBe("SOMI");
+  });
 });
 
 describe("EIP155_SEPOLIA_CHAINS", () => {

--- a/src/data/network.config.ts
+++ b/src/data/network.config.ts
@@ -100,6 +100,13 @@ export const EIP155_CHAINS_MAINNET: Record<string, Network> = {
     displayName: "Sei EVM",
     color: "#7B2CBF",
   },
+  somnia: {
+    chainId: 5031,
+    namespace: "eip155:5031",
+    ticker: "SOMI",
+    displayName: "Somnia",
+    color: "#6F0191",
+  },
 };
 
 export const EIP155_SEPOLIA_CHAINS: Record<string, Network> = {


### PR DESCRIPTION
### 📝 Description

Adds **Somnia** (EVM, chain id `5031`) to the WalletConnect live app so dApps can connect to a Somnia account in Ledger Live.

Somnia is already a supported Ledger Live currency (`somnia`, family `evm`), so this is config-only — the chain routes through the existing EIP155 request handler, with no new handler or capability gate. Changes:

- Register the chain in `EIP155_CHAINS_MAINNET` (`eip155:5031`, ticker `SOMI`); the map key `somnia` matches the Ledger Live currency id so accounts resolve.
- Add `somnia` to the local manifest currencies and the README support table.
- Add a `SUPPORTED_NETWORK` unit test for the new entry.

### ❓ Context

- **Linked resource(s)**: [LIVE-31176](https://ledgerhq.atlassian.net/browse/LIVE-31176)

### 📸 Demo

_dApp connection on Somnia to be verified during QA._

### 🚀 Expectations to reach

CI green and internal validation.


[LIVE-31176]: https://ledgerhq.atlassian.net/browse/LIVE-31176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ