### PR TITLE
feat: add Etherlink network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ and is intended to be integrated within ledger products, enabling users to seaml
 | ADI Chain         | ✅          | -                  |                    |
 | Sei EVM           | ✅          | -                  | -                  |
 | Somnia            | ✅          | -                  | -                  |
+| Etherlink         | ✅          | -                  | -                  |
 
 ## Hosting
 

--- a/localManifest.json
+++ b/localManifest.json
@@ -38,6 +38,7 @@
     "ripple",
     "sei_evm",
     "somnia",
+    "etherlink",
     "ethereum_holesky"
   ],
   "content": {

--- a/src/data/__tests__/networkConfig.test.ts
+++ b/src/data/__tests__/networkConfig.test.ts
@@ -86,6 +86,15 @@ describe("SUPPORTED_NETWORK", () => {
     expect(somnia?.namespace).toBe("eip155:5031");
     expect(somnia?.ticker).toBe("SOMI");
   });
+
+  it("contains Etherlink", () => {
+    const etherlink: Network | undefined = SUPPORTED_NETWORK.etherlink;
+
+    expect(etherlink?.displayName).toBe("Etherlink");
+    expect(etherlink?.chainId).toBe(42793);
+    expect(etherlink?.namespace).toBe("eip155:42793");
+    expect(etherlink?.ticker).toBe("XTZ");
+  });
 });
 
 describe("EIP155_SEPOLIA_CHAINS", () => {

--- a/src/data/network.config.ts
+++ b/src/data/network.config.ts
@@ -107,6 +107,13 @@ export const EIP155_CHAINS_MAINNET: Record<string, Network> = {
     displayName: "Somnia",
     color: "#6F0191",
   },
+  etherlink: {
+    chainId: 42793,
+    namespace: "eip155:42793",
+    ticker: "XTZ",
+    displayName: "Etherlink",
+    color: "#38FF9C",
+  },
 };
 
 export const EIP155_SEPOLIA_CHAINS: Record<string, Network> = {


### PR DESCRIPTION
### 📝 Description

Adds **Etherlink** (EVM, chain id `42793`) to the WalletConnect live app so dApps can connect to an Etherlink account in Ledger Live.

Etherlink is already a supported Ledger Live currency (`etherlink`, family `evm`), so this is config-only — the chain routes through the existing EIP155 request handler, with no new handler or capability gate. Changes:

- Register the chain in `EIP155_CHAINS_MAINNET` (`eip155:42793`, ticker `XTZ`); the map key `etherlink` matches the Ledger Live currency id so accounts resolve.
- Add `etherlink` to the local manifest currencies and the README support table.
- Add a `SUPPORTED_NETWORK` unit test for the new entry.

### ❓ Context

- **Linked resource(s)**: [LIVE-31177](https://ledgerhq.atlassian.net/browse/LIVE-31177)

### 📸 Demo

_dApp connection on Etherlink to be verified during QA._

### 🚀 Expectations to reach

CI green and internal validation.


[LIVE-31177]: https://ledgerhq.atlassian.net/browse/LIVE-31177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ