### PR TITLE
feat: add 0G network support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and is intended to be integrated within ledger products, enabling users to seaml
 | Sei EVM           | ✅          | -                  | -                  |
 | Somnia            | ✅          | -                  | -                  |
 | Etherlink         | ✅          | -                  | -                  |
+| 0G                | ✅          | -                  | -                  |
 
 ## Hosting
 

--- a/localManifest.json
+++ b/localManifest.json
@@ -39,6 +39,7 @@
     "sei_evm",
     "somnia",
     "etherlink",
+    "zero_gravity",
     "ethereum_holesky"
   ],
   "content": {

--- a/src/data/__tests__/networkConfig.test.ts
+++ b/src/data/__tests__/networkConfig.test.ts
@@ -95,6 +95,15 @@ describe("SUPPORTED_NETWORK", () => {
     expect(etherlink?.namespace).toBe("eip155:42793");
     expect(etherlink?.ticker).toBe("XTZ");
   });
+
+  it("contains 0G", () => {
+    const zeroGravity: Network | undefined = SUPPORTED_NETWORK.zero_gravity;
+
+    expect(zeroGravity?.displayName).toBe("0G");
+    expect(zeroGravity?.chainId).toBe(16661);
+    expect(zeroGravity?.namespace).toBe("eip155:16661");
+    expect(zeroGravity?.ticker).toBe("0G");
+  });
 });
 
 describe("EIP155_SEPOLIA_CHAINS", () => {

--- a/src/data/network.config.ts
+++ b/src/data/network.config.ts
@@ -114,6 +114,13 @@ export const EIP155_CHAINS_MAINNET: Record<string, Network> = {
     displayName: "Etherlink",
     color: "#38FF9C",
   },
+  zero_gravity: {
+    chainId: 16661,
+    namespace: "eip155:16661",
+    ticker: "0G",
+    displayName: "0G",
+    color: "#9200E1",
+  },
 };
 
 export const EIP155_SEPOLIA_CHAINS: Record<string, Network> = {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Adds **0G** (EVM, chain id `16661`) to the WalletConnect live app so dApps can connect to a 0G account in Ledger Live.

0G is already a supported Ledger Live currency (`zero_gravity`, family `evm`), so this is config-only — the chain routes through the existing EIP155 request handler, with no new handler or capability gate. Changes:

- Register the chain in `EIP155_CHAINS_MAINNET` (`eip155:16661`, ticker `0G`); the map key `zero_gravity` matches the Ledger Live currency id so accounts resolve.
- Add `zero_gravity` to the local manifest currencies and the README support table.
- Add a `SUPPORTED_NETWORK` unit test for the new entry.

### ❓ Context

- **Linked resource(s)**: [LIVE-31175](https://ledgerhq.atlassian.net/browse/LIVE-31175)

### 📸 Demo

dApp connection on 0G to be verified during QA.

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-31175]: https://ledgerhq.atlassian.net/browse/LIVE-31175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ