### PR TITLE
feat: add Babylon (cosmos:bbn-1) to WalletConnect supported chains (L…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and is intended to be integrated within ledger products, enabling users to seaml
 | Avalanche C-Chain | ✅          | -                  |                    |
 | Rootstock         | ✅          | -                  |                    |
 | Base              | ✅          | ✅                 |                    |
-| Cosmos            | ⏳          | -                  |                    |
+| Babylon           | ✅          | -                  |                    |
 | Multivers-X       | ✅          | -                  |                    |
 | Solana            | ✅          | -                  |                    |
 | Monad             | ✅          | ✅                 |                    |

--- a/localManifest.json
+++ b/localManifest.json
@@ -44,7 +44,8 @@
     "arc",
     "arc_testnet",
     "ethereum_holesky",
-    "tezos"
+    "tezos",
+    "babylon"
   ],
   "content": {
     "shortDescription": {

--- a/src/data/__tests__/networkConfig.test.ts
+++ b/src/data/__tests__/networkConfig.test.ts
@@ -113,6 +113,15 @@ describe("SUPPORTED_NETWORK", () => {
     expect(tezos?.namespace).toBe("tezos:NetXdQprcVkpaWU");
     expect(tezos?.ticker).toBe("XTZ");
   });
+
+  it("contains Babylon", () => {
+    const babylon: Network | undefined = SUPPORTED_NETWORK.babylon;
+
+    expect(babylon?.displayName).toBe("Babylon");
+    expect(babylon?.chainId).toBe("bbn-1");
+    expect(babylon?.namespace).toBe("cosmos:bbn-1");
+    expect(babylon?.ticker).toBe("BABY");
+  });
 });
 
 describe("EIP155_SEPOLIA_CHAINS", () => {

--- a/src/data/__tests__/networkConfig.test.ts
+++ b/src/data/__tests__/networkConfig.test.ts
@@ -1,5 +1,6 @@
 import { SUPPORTED_NETWORK } from "@/data/network.config";
 import { Network } from "@/data/types";
+import { getCurrencyByChainId, getNamespace } from "@/utils/helper.util";
 
 describe("SUPPORTED_NETWORK", () => {
   it("contains Ethereum", () => {
@@ -121,6 +122,14 @@ describe("SUPPORTED_NETWORK", () => {
     expect(babylon?.chainId).toBe("bbn-1");
     expect(babylon?.namespace).toBe("cosmos:bbn-1");
     expect(babylon?.ticker).toBe("BABY");
+  });
+
+  it("resolves Babylon from its CAIP-2 chain id", () => {
+    // Acceptance criterion (LIVE-33214): Babylon resolves as a supported cosmos
+    // chain under CAIP-2 cosmos:bbn-1. Assert both directions of the resolvers so
+    // the entry stays discoverable, not merely present.
+    expect(getCurrencyByChainId("cosmos:bbn-1")).toBe("babylon");
+    expect(getNamespace("babylon")).toBe("cosmos:bbn-1");
   });
 });
 

--- a/src/data/methods/Cosmos.methods.ts
+++ b/src/data/methods/Cosmos.methods.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+/**
+ * Methods
+ *
+ * Only the amino methods are advertised: coin-cosmos signs amino `StdSignDoc`s exclusively.
+ * `cosmos_signDirect` (protobuf) is intentionally omitted so `buildCosmosNamespace` never
+ * negotiates it; the handler rejects it with 5101 if a dApp sends it anyway.
+ */
+export const COSMOS_SIGNING_METHODS = {
+  COSMOS_GET_ACCOUNTS: "cosmos_getAccounts",
+  COSMOS_SIGN_AMINO: "cosmos_signAmino",
+} as const;
+
+export const cosmosGetAccountsSchema = z.strictObject({}).optional();
+
+/**
+ * Amino `StdSignDoc`. Kept permissive (`looseObject`) — coin-cosmos re-validates the structure
+ * and signs the canonical serialized bytes verbatim, so we only strictly need `signerAddress`
+ * to resolve the account. The guaranteed fields mirror coin-cosmos's own `assertValidStdSignDoc`.
+ */
+export const cosmosSignAminoSchema = z.strictObject({
+  signerAddress: z.string(),
+  signDoc: z.looseObject({
+    chain_id: z.string(),
+    account_number: z.string(),
+    sequence: z.string(),
+    fee: z.looseObject({
+      amount: z.array(z.unknown()),
+      gas: z.string(),
+    }),
+    msgs: z.array(z.unknown()).min(1),
+    memo: z.string(),
+  }),
+});
+
+export type CosmosAccount = {
+  algo: string;
+  address: string;
+  pubkey: string;
+};
+
+export type CosmosSignAminoResponse = {
+  signature: {
+    pub_key: { type: string; value: string };
+    signature: string;
+  };
+  signed: unknown;
+};
+
+/**
+ * Requests specs: https://docs.reown.com/advanced/multichain/rpc-reference/cosmos-rpc
+ */
+export type COSMOS_REQUESTS =
+  | {
+      method: typeof COSMOS_SIGNING_METHODS.COSMOS_GET_ACCOUNTS;
+      params: z.infer<typeof cosmosGetAccountsSchema>;
+    }
+  | {
+      method: typeof COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO;
+      params: z.infer<typeof cosmosSignAminoSchema>;
+    };
+
+/**
+ * Responses specs: https://docs.reown.com/advanced/multichain/rpc-reference/cosmos-rpc
+ */
+export type COSMOS_RESPONSES = {
+  [COSMOS_SIGNING_METHODS.COSMOS_GET_ACCOUNTS]: CosmosAccount[];
+  [COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO]: CosmosSignAminoResponse;
+};

--- a/src/data/network.config.ts
+++ b/src/data/network.config.ts
@@ -302,6 +302,16 @@ export const TEZOS_CHAINS: Record<string, Network> = {
   },
 };
 
+export const COSMOS_CHAINS: Record<string, Network> = {
+  babylon: {
+    chainId: "bbn-1",
+    namespace: "cosmos:bbn-1",
+    ticker: "BABY",
+    displayName: "Babylon",
+    color: "#CE6533",
+  },
+};
+
 export const EIP155_CHAINS = {
   ...EIP155_CHAINS_MAINNET,
   ...EIP155_SEPOLIA_CHAINS,
@@ -317,6 +327,7 @@ export const SUPPORTED_NETWORK: Record<string, Network> = {
   ...RIPPLE_CHAINS,
   ...SOLANA_CHAINS,
   ...TEZOS_CHAINS,
+  ...COSMOS_CHAINS,
 };
 
 export const SUPPORTED_NETWORK_NAMES: string[] = Object.values(
@@ -329,4 +340,5 @@ export enum SupportedNamespace {
   XRPL = "xrpl",
   SOLANA = "solana",
   TEZOS = "tezos",
+  COSMOS = "cosmos",
 }

--- a/src/hooks/__tests__/useSupportedNamespaces.test.ts
+++ b/src/hooks/__tests__/useSupportedNamespaces.test.ts
@@ -544,4 +544,92 @@ describe("useSupportedNamespaces", () => {
 
     expect(result.current.buildSupportedNamespaces(proposal)).toEqual({});
   });
+
+  it("builds the cosmos namespace and drops cosmos_signDirect when the version gate is on", () => {
+    const bbn = makeAccount("bbn-1", "babylon", "bbn1abc");
+
+    mockedUseAccounts.mockReturnValue({
+      data: [bbn],
+    } as ReturnType<typeof useAccounts>);
+
+    store.set(walletInfoAtom as never, {
+      wallet: { name: "ledger-live-desktop", version: "4.11.0" },
+      tracking: false,
+    } satisfies WalletInfo["result"]);
+
+    mockedFormatAccountsByChain.mockReturnValue([
+      {
+        chain: "babylon",
+        displayName: "Babylon",
+        isSupported: true,
+        isRequired: true,
+        accounts: [bbn],
+      },
+    ]);
+
+    const proposal = {
+      ...sessionProposal,
+      requiredNamespaces: {
+        cosmos: {
+          // signDirect is requested but unsupported — it must be filtered out.
+          methods: ["cosmos_getAccounts", "cosmos_signAmino", "cosmos_signDirect"],
+          chains: ["cosmos:bbn-1"],
+          events: [],
+        },
+      },
+      optionalNamespaces: {},
+    };
+
+    const { result } = renderHook(
+      () => useSupportedNamespaces(proposal, ["bbn-1"]),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    expect(result.current.buildSupportedNamespaces(proposal)).toEqual({
+      cosmos: {
+        chains: ["cosmos:bbn-1"],
+        methods: ["cosmos_getAccounts", "cosmos_signAmino"],
+        events: [],
+        accounts: ["cosmos:bbn-1:bbn1abc"],
+      },
+    });
+  });
+
+  it("omits the cosmos namespace when the version gate is disabled", () => {
+    const bbn = makeAccount("bbn-1", "babylon", "bbn1abc");
+
+    mockedUseAccounts.mockReturnValue({
+      data: [bbn],
+    } as ReturnType<typeof useAccounts>);
+
+    // baseWalletInfo is 2.127.0 (< 4.11.0), so cosmos support is off.
+    mockedFormatAccountsByChain.mockReturnValue([
+      {
+        chain: "babylon",
+        displayName: "Babylon",
+        isSupported: true,
+        isRequired: false,
+        accounts: [bbn],
+      },
+    ]);
+
+    const proposal = {
+      ...sessionProposal,
+      requiredNamespaces: {},
+      optionalNamespaces: {
+        cosmos: {
+          methods: ["cosmos_signAmino"],
+          chains: ["cosmos:bbn-1"],
+          events: [],
+        },
+      },
+    };
+
+    const { result } = renderHook(
+      () => useSupportedNamespaces(proposal, ["bbn-1"]),
+      { wrapper: createHookWrapper(store) },
+    );
+
+    expect(result.current.buildSupportedNamespaces(proposal)).toEqual({});
+  });
 });

--- a/src/hooks/__tests__/useWalletConnect.test.ts
+++ b/src/hooks/__tests__/useWalletConnect.test.ts
@@ -5,6 +5,7 @@ import { enqueueSnackbar } from "notistack";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ZodError } from "zod";
 import { handleBIP122Request } from "../requestHandlers/BIP122";
+import { handleCosmosRequest } from "../requestHandlers/Cosmos";
 import { handleEIP155Request } from "../requestHandlers/EIP155";
 import { handleXrpRequest } from "../requestHandlers/Ripple";
 import { handleSolanaRequest } from "../requestHandlers/Solana";
@@ -46,6 +47,10 @@ vi.mock("../useAccounts", () => ({
 
 vi.mock("../requestHandlers/BIP122", () => ({
   handleBIP122Request: vi.fn(),
+}));
+
+vi.mock("../requestHandlers/Cosmos", () => ({
+  handleCosmosRequest: vi.fn(),
 }));
 
 vi.mock("../requestHandlers/EIP155", () => ({
@@ -128,6 +133,7 @@ const mockedUseAccounts = vi.mocked(useAccounts);
 const mockedHandleWalletRequest = vi.mocked(handleWalletRequest);
 const mockedHandleEIP155Request = vi.mocked(handleEIP155Request);
 const mockedHandleBIP122Request = vi.mocked(handleBIP122Request);
+const mockedHandleCosmosRequest = vi.mocked(handleCosmosRequest);
 const mockedHandleXrpRequest = vi.mocked(handleXrpRequest);
 const mockedHandleSolanaRequest = vi.mocked(handleSolanaRequest);
 const mockedHandleTezosRequest = vi.mocked(handleTezosRequest);
@@ -221,6 +227,7 @@ describe("useWalletConnect", () => {
     mockedHandleWalletRequest.mockResolvedValue(undefined);
     mockedHandleEIP155Request.mockResolvedValue(undefined);
     mockedHandleBIP122Request.mockResolvedValue(undefined);
+    mockedHandleCosmosRequest.mockResolvedValue(undefined);
     mockedHandleXrpRequest.mockResolvedValue(undefined);
     mockedHandleSolanaRequest.mockResolvedValue(undefined);
     mockedHandleTezosRequest.mockResolvedValue(undefined);
@@ -458,6 +465,92 @@ describe("useWalletConnect", () => {
         walletKitMock,
         "topic-1",
         9,
+        Errors.unsupportedChains,
+        5100,
+      );
+    });
+  });
+
+  it("dispatches cosmos requests to the cosmos handler when the version gate is on", async () => {
+    store.set(walletInfoAtom as never, {
+      wallet: { name: "ledger-live-desktop", version: "4.11.0" },
+      tracking: false,
+    });
+
+    mountHook();
+
+    walletKitListeners.get("session_request")?.({
+      topic: "topic-1",
+      id: 11,
+      params: {
+        chainId: "cosmos:bbn-1",
+        request: { method: "cosmos_signAmino", params: {} },
+      },
+      verifyContext: {},
+    });
+
+    await waitFor(() => {
+      expect(mockedHandleCosmosRequest).toHaveBeenCalled();
+    });
+  });
+
+  it("scopes cosmos requests to the session-approved accounts", async () => {
+    store.set(walletInfoAtom as never, {
+      wallet: { name: "ledger-live-desktop", version: "4.11.0" },
+      tracking: false,
+    });
+
+    const approved = { id: "bbn-1", address: "bbn1approved", currency: "babylon" };
+    const unapproved = { id: "bbn-2", address: "bbn1other", currency: "babylon" };
+    mockedUseAccounts.mockReturnValue({
+      data: [approved, unapproved],
+    } as ReturnType<typeof useAccounts>);
+    walletKitMock.engine.signClient.session.get.mockReturnValue({
+      ...sessionRecord,
+      namespaces: {
+        ...sessionRecord.namespaces,
+        cosmos: { accounts: ["cosmos:bbn-1:bbn1approved"] },
+      },
+    } as typeof sessionRecord);
+
+    mountHook();
+
+    walletKitListeners.get("session_request")?.({
+      topic: "topic-1",
+      id: 12,
+      params: {
+        chainId: "cosmos:bbn-1",
+        request: { method: "cosmos_getAccounts", params: {} },
+      },
+      verifyContext: {},
+    });
+
+    await waitFor(() => {
+      expect(mockedHandleCosmosRequest).toHaveBeenCalled();
+    });
+    expect(mockedHandleCosmosRequest.mock.calls[0][4]).toEqual([approved]);
+  });
+
+  it("rejects cosmos requests when the version gate is disabled", async () => {
+    // Default walletInfo is 2.127.0 (< 4.11.0), so cosmos support is off.
+    mountHook();
+
+    walletKitListeners.get("session_request")?.({
+      topic: "topic-1",
+      id: 13,
+      params: {
+        chainId: "cosmos:bbn-1",
+        request: { method: "cosmos_signAmino", params: {} },
+      },
+      verifyContext: {},
+    });
+
+    await waitFor(() => {
+      expect(mockedHandleCosmosRequest).not.toHaveBeenCalled();
+      expect(mockedRejectRequest).toHaveBeenCalledWith(
+        walletKitMock,
+        "topic-1",
+        13,
         Errors.unsupportedChains,
         5100,
       );

--- a/src/hooks/requestHandlers/Cosmos.test.ts
+++ b/src/hooks/requestHandlers/Cosmos.test.ts
@@ -1,0 +1,290 @@
+import { COSMOS_SIGNING_METHODS } from "@/data/methods/Cosmos.methods";
+import { hexToBase64 } from "@/utils/cosmos";
+import * as utilsGeneric from "@/utils/generic";
+import { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleCosmosRequest } from "./Cosmos";
+import * as utils from "./utils";
+
+vi.mock("./utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof utils>()),
+  acceptRequest: vi.fn(),
+  rejectRequest: vi.fn(),
+}));
+vi.mock("@/utils/generic");
+
+const BBN = "bbn1testaccount";
+const PUBKEY_HEX = "02" + "ab".repeat(32); // 33-byte compressed secp256k1 pubkey
+const SIG_HEX = "cd".repeat(64); // 64-byte r‖s signature
+const topic = "topic";
+const id = 0;
+const chainId = "cosmos:bbn-1";
+
+const signDoc = {
+  chain_id: "bbn-1",
+  account_number: "1",
+  sequence: "0",
+  fee: { amount: [{ denom: "ubbn", amount: "500" }], gas: "200000" },
+  msgs: [{ type: "cosmos-sdk/MsgSend", value: {} }],
+  memo: "",
+};
+
+describe("handleCosmosRequest", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("cosmos_getAccounts", () => {
+    it("returns only Babylon accounts mapped to {algo, address, pubkey(base64)}", async () => {
+      const accounts = [
+        { id: "1", address: BBN, currency: "babylon" },
+        { id: "2", address: "0xabc", currency: "ethereum" },
+      ] as unknown as Account[];
+
+      const getPublicKey = vi.fn().mockResolvedValue(PUBKEY_HEX);
+      const client = { account: { getPublicKey } } as unknown as WalletAPIClient;
+
+      const acceptRequestSpy = vi
+        .spyOn(utils, "acceptRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        { method: COSMOS_SIGNING_METHODS.COSMOS_GET_ACCOUNTS, params: {} },
+        topic,
+        id,
+        chainId,
+        accounts,
+        client,
+        {} as IWalletKit,
+      );
+
+      expect(getPublicKey).toHaveBeenCalledTimes(1);
+      expect(getPublicKey).toHaveBeenCalledWith("1");
+      expect(acceptRequestSpy).toHaveBeenCalledWith(expect.anything(), topic, id, [
+        { algo: "secp256k1", address: BBN, pubkey: hexToBase64(PUBKEY_HEX) },
+      ]);
+    });
+
+    it("omits accounts whose public key cannot be fetched", async () => {
+      const accounts = [
+        { id: "1", address: BBN, currency: "babylon" },
+      ] as unknown as Account[];
+
+      const getPublicKey = vi.fn().mockRejectedValue(new Error("not implemented"));
+      const client = { account: { getPublicKey } } as unknown as WalletAPIClient;
+
+      const acceptRequestSpy = vi
+        .spyOn(utils, "acceptRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        { method: COSMOS_SIGNING_METHODS.COSMOS_GET_ACCOUNTS, params: {} },
+        topic,
+        id,
+        chainId,
+        accounts,
+        client,
+        {} as IWalletKit,
+      );
+
+      expect(acceptRequestSpy).toHaveBeenCalledWith(expect.anything(), topic, id, []);
+    });
+
+    it("omits accounts whose public key is empty (synced before LIVE-33211)", async () => {
+      const accounts = [
+        { id: "1", address: BBN, currency: "babylon" },
+      ] as unknown as Account[];
+
+      const getPublicKey = vi.fn().mockResolvedValue("");
+      const client = { account: { getPublicKey } } as unknown as WalletAPIClient;
+
+      const acceptRequestSpy = vi
+        .spyOn(utils, "acceptRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        { method: COSMOS_SIGNING_METHODS.COSMOS_GET_ACCOUNTS, params: {} },
+        topic,
+        id,
+        chainId,
+        accounts,
+        client,
+        {} as IWalletKit,
+      );
+
+      expect(acceptRequestSpy).toHaveBeenCalledWith(expect.anything(), topic, id, []);
+    });
+  });
+
+  describe("cosmos_signAmino", () => {
+    it("signs the amino doc and returns pub_key + base64 signature + echoed signDoc", async () => {
+      vi.spyOn(utilsGeneric, "getAccountWithAddressAndChainId").mockReturnValueOnce(
+        { id: "acc-1", address: BBN } as Account,
+      );
+      const getPublicKey = vi.fn().mockResolvedValue(PUBKEY_HEX);
+      const signRaw = vi
+        .fn()
+        .mockResolvedValueOnce({ signedTransactionHex: SIG_HEX });
+      const client = {
+        account: { getPublicKey },
+        transaction: { signRaw },
+      } as unknown as WalletAPIClient;
+
+      const acceptRequestSpy = vi
+        .spyOn(utils, "acceptRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        {
+          method: COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO,
+          params: { signerAddress: BBN, signDoc },
+        },
+        topic,
+        id,
+        chainId,
+        [],
+        client,
+        {} as IWalletKit,
+      );
+
+      // broadcast=false: the dApp assembles and broadcasts the final tx.
+      expect(signRaw).toHaveBeenCalledWith("acc-1", JSON.stringify(signDoc), false);
+      expect(acceptRequestSpy).toHaveBeenCalledWith(expect.anything(), topic, id, {
+        signature: {
+          pub_key: {
+            type: "tendermint/PubKeySecp256k1",
+            value: hexToBase64(PUBKEY_HEX),
+          },
+          signature: hexToBase64(SIG_HEX),
+        },
+        signed: signDoc,
+      });
+    });
+
+    it("rejects when no matching account is found", async () => {
+      vi.spyOn(utilsGeneric, "getAccountWithAddressAndChainId").mockReturnValueOnce(
+        undefined,
+      );
+      const rejectRequestSpy = vi
+        .spyOn(utils, "rejectRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        {
+          method: COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO,
+          params: { signerAddress: BBN, signDoc },
+        },
+        topic,
+        id,
+        chainId,
+        [],
+        {
+          account: { getPublicKey: vi.fn() },
+          transaction: { signRaw: vi.fn() },
+        } as unknown as WalletAPIClient,
+        {} as IWalletKit,
+      );
+
+      expect(rejectRequestSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        topic,
+        id,
+        utils.Errors.txDeclined,
+      );
+    });
+
+    it("rejects when the signer account has no persisted public key", async () => {
+      vi.spyOn(utilsGeneric, "getAccountWithAddressAndChainId").mockReturnValueOnce(
+        { id: "acc-1", address: BBN } as Account,
+      );
+      const signRaw = vi.fn();
+      const client = {
+        account: { getPublicKey: vi.fn().mockResolvedValue("") },
+        transaction: { signRaw },
+      } as unknown as WalletAPIClient;
+      const rejectRequestSpy = vi
+        .spyOn(utils, "rejectRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        {
+          method: COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO,
+          params: { signerAddress: BBN, signDoc },
+        },
+        topic,
+        id,
+        chainId,
+        [],
+        client,
+        {} as IWalletKit,
+      );
+
+      expect(signRaw).not.toHaveBeenCalled();
+      expect(rejectRequestSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        topic,
+        id,
+        utils.Errors.txDeclined,
+      );
+    });
+
+    it("rejects (does not throw) when the user cancels on device", async () => {
+      vi.spyOn(utilsGeneric, "getAccountWithAddressAndChainId").mockReturnValueOnce(
+        { id: "acc-1", address: BBN } as Account,
+      );
+      const canceled = Object.assign(new Error("cancelled"), {
+        name: "UserRefusedOnDevice",
+      });
+      const client = {
+        account: { getPublicKey: vi.fn().mockResolvedValue(PUBKEY_HEX) },
+        transaction: { signRaw: vi.fn().mockRejectedValueOnce(canceled) },
+      } as unknown as WalletAPIClient;
+      const rejectRequestSpy = vi
+        .spyOn(utils, "rejectRequest")
+        .mockResolvedValueOnce(undefined);
+
+      await handleCosmosRequest(
+        {
+          method: COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO,
+          params: { signerAddress: BBN, signDoc },
+        },
+        topic,
+        id,
+        chainId,
+        [],
+        client,
+        {} as IWalletKit,
+      );
+
+      expect(rejectRequestSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        topic,
+        id,
+        utils.Errors.txDeclined,
+      );
+    });
+  });
+
+  it("rejects cosmos_signDirect and other unsupported methods with code 5101", async () => {
+    const rejectRequestSpy = vi
+      .spyOn(utils, "rejectRequest")
+      .mockResolvedValue(undefined);
+
+    await handleCosmosRequest(
+      { method: "cosmos_signDirect" } as never,
+      topic,
+      id,
+      chainId,
+      [],
+      {} as WalletAPIClient,
+      {} as IWalletKit,
+    );
+
+    expect(rejectRequestSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      topic,
+      id,
+      utils.Errors.unsupportedMethods,
+      5101,
+    );
+  });
+});

--- a/src/hooks/requestHandlers/Cosmos.ts
+++ b/src/hooks/requestHandlers/Cosmos.ts
@@ -1,0 +1,135 @@
+import {
+  type COSMOS_REQUESTS,
+  type COSMOS_RESPONSES,
+  COSMOS_SIGNING_METHODS,
+  type CosmosAccount,
+  cosmosSignAminoSchema,
+} from "@/data/methods/Cosmos.methods";
+import { hexToBase64 } from "@/utils/cosmos";
+import { getAccountWithAddressAndChainId } from "@/utils/generic";
+import type { Account, WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import type { IWalletKit } from "@reown/walletkit";
+import { acceptRequest, Errors, isCanceledError, rejectRequest } from "./utils";
+
+const LEDGER_LIVE_CURRENCY = "babylon";
+const COSMOS_PUBKEY_ALGO = "secp256k1";
+const COSMOS_PUBKEY_TYPE = "tendermint/PubKeySecp256k1";
+
+async function getAccounts(
+  accounts: Account[],
+  client: WalletAPIClient,
+  walletKit: IWalletKit,
+  topic: string,
+  id: number,
+) {
+  // pubkey is mandatory in the RPC response. coin-cosmos only persists it for accounts synced
+  // after LIVE-33211; older ones resolve to an empty key. Skip any account without one (throw
+  // OR empty) rather than advertising an unusable account.
+  const cosmosAccounts: CosmosAccount[] = (
+    await Promise.all(
+      accounts
+        .filter((account) => account.currency === LEDGER_LIVE_CURRENCY)
+        .map(async (account) => {
+          try {
+            const pubkey = await client.account.getPublicKey(account.id);
+            if (!pubkey) return null;
+            return {
+              algo: COSMOS_PUBKEY_ALGO,
+              address: account.address,
+              pubkey: hexToBase64(pubkey),
+            };
+          } catch {
+            return null;
+          }
+        }),
+    )
+  ).filter((account): account is CosmosAccount => account !== null);
+
+  await acceptRequest(walletKit, topic, id, cosmosAccounts);
+}
+
+async function signAmino(
+  request: Extract<
+    COSMOS_REQUESTS,
+    { method: typeof COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO }
+  >,
+  accounts: Account[],
+  client: WalletAPIClient,
+  walletKit: IWalletKit,
+  topic: string,
+  id: number,
+) {
+  const params = cosmosSignAminoSchema.parse(request.params);
+  const account = getAccountWithAddressAndChainId(
+    accounts,
+    params.signerAddress,
+    LEDGER_LIVE_CURRENCY,
+  );
+
+  if (!account || account.address !== params.signerAddress) {
+    await rejectRequest(walletKit, topic, id, Errors.txDeclined);
+    return;
+  }
+
+  try {
+    // The amino response must carry the signer's public key; coin-cosmos exposes it only for
+    // accounts synced after LIVE-33211, so bail clearly (prompt re-sync) when it's missing.
+    const pubkey = await client.account.getPublicKey(account.id);
+    if (!pubkey) {
+      await rejectRequest(walletKit, topic, id, Errors.txDeclined);
+      return;
+    }
+
+    // coin-cosmos signs the canonical amino bytes and returns the detached 64-byte secp256k1
+    // signature as hex via `signedTransactionHex`; it never broadcasts (broadcast=false).
+    const { signedTransactionHex } = await client.transaction.signRaw(
+      account.id,
+      JSON.stringify(params.signDoc),
+      false,
+    );
+
+    if (!signedTransactionHex) {
+      await rejectRequest(walletKit, topic, id, Errors.txDeclined);
+      return;
+    }
+
+    const result: COSMOS_RESPONSES[typeof request.method] = {
+      signature: {
+        pub_key: { type: COSMOS_PUBKEY_TYPE, value: hexToBase64(pubkey) },
+        signature: hexToBase64(signedTransactionHex),
+      },
+      // Echo the exact signDoc back, as the amino spec requires.
+      signed: params.signDoc,
+    };
+
+    await acceptRequest(walletKit, topic, id, result);
+  } catch (error) {
+    if (isCanceledError(error)) {
+      await rejectRequest(walletKit, topic, id, Errors.txDeclined);
+    } else {
+      throw error;
+    }
+  }
+}
+
+export async function handleCosmosRequest(
+  request: COSMOS_REQUESTS,
+  topic: string,
+  id: number,
+  _chainId: string,
+  accounts: Account[],
+  client: WalletAPIClient,
+  walletKit: IWalletKit,
+) {
+  switch (request.method) {
+    case COSMOS_SIGNING_METHODS.COSMOS_GET_ACCOUNTS:
+      await getAccounts(accounts, client, walletKit, topic, id);
+      break;
+    case COSMOS_SIGNING_METHODS.COSMOS_SIGN_AMINO:
+      await signAmino(request, accounts, client, walletKit, topic, id);
+      break;
+    // cosmos_signDirect (protobuf) and anything else: coin-cosmos is amino-only.
+    default:
+      await rejectRequest(walletKit, topic, id, Errors.unsupportedMethods, 5101);
+  }
+}

--- a/src/hooks/useSupportedNamespaces.ts
+++ b/src/hooks/useSupportedNamespaces.ts
@@ -2,6 +2,7 @@ import {
   BIP122_QUERY_METHODS,
   BIP122_SIGNING_METHODS,
 } from "@/data/methods/BIP122.methods";
+import { COSMOS_SIGNING_METHODS } from "@/data/methods/Cosmos.methods";
 import { EIP155_SIGNING_METHODS } from "@/data/methods/EIP155Data.methods";
 import { RIPPLE_SIGNING_METHODS } from "@/data/methods/Ripple.methods";
 import { SOLANA_SIGNING_METHODS } from "@/data/methods/Solana.methods";
@@ -9,6 +10,7 @@ import { TEZOS_SIGNING_METHODS } from "@/data/methods/Tezos.methods";
 import { WALLET_METHODS } from "@/data/methods/Wallet.methods";
 import {
   BIP122_CHAINS,
+  COSMOS_CHAINS,
   EIP155_CHAINS,
   RIPPLE_CHAINS,
   SOLANA_CHAINS,
@@ -24,6 +26,7 @@ import {
 } from "@/store/wallet-api.store";
 import {
   getNamespace,
+  isCosmosSupportEnabled,
   isSolanaSupportEnabled,
   isTezosSupportEnabled,
   isXRPLSupportEnabled,
@@ -389,6 +392,82 @@ export function useSupportedNamespaces(
     [session, accounts.data, walletInfo, walletCapabilities, selectedAccounts],
   );
 
+  const buildCosmosNamespace = useCallback(
+    (
+      requiredNamespaces: ProposalTypes.RequiredNamespaces,
+      optionalNamespaces: ProposalTypes.OptionalNamespaces,
+    ) => {
+      const accountsByChain = formatAccountsByChain(
+        session,
+        accounts.data,
+        walletInfo,
+        walletCapabilities,
+      ).filter(
+        (a) =>
+          a.accounts.length > 0 &&
+          a.isSupported &&
+          Object.keys(COSMOS_CHAINS).includes(a.chain),
+      );
+
+      const supportedMethods = new Set<string>([
+        ...Object.values(WALLET_METHODS),
+        ...Object.values(COSMOS_SIGNING_METHODS),
+      ]);
+
+      const registeredNamespaces = new Set(
+        Object.values(COSMOS_CHAINS).map((network) => network.namespace),
+      );
+      const requestedChains = [
+        ...new Set([
+          ...(requiredNamespaces[SupportedNamespace.COSMOS]?.chains ?? []),
+          ...(optionalNamespaces[SupportedNamespace.COSMOS]?.chains ?? []),
+        ]),
+      ].filter((chain) => registeredNamespaces.has(chain));
+
+      const selectedCosmosAccounts = Array.from(
+        new Map(
+          accountsByChain
+            .flatMap((elem) => elem.accounts)
+            .filter((acc) => selectedAccounts.includes(acc.id))
+            .map((acc) => [acc.id, acc] as const),
+        ).values(),
+      );
+
+      const dataToSend = requestedChains.flatMap((chain) =>
+        selectedCosmosAccounts.map((a) => ({
+          account: `${chain}:${a.address}`,
+          chain,
+        })),
+      );
+
+      const methods = [
+        ...new Set([
+          ...(requiredNamespaces[SupportedNamespace.COSMOS]?.methods.filter(
+            (method) => supportedMethods.has(method),
+          ) ?? []),
+          ...(optionalNamespaces[SupportedNamespace.COSMOS]?.methods.filter(
+            (method) => supportedMethods.has(method),
+          ) ?? []),
+        ]),
+      ];
+
+      const events = [
+        ...new Set([
+          ...(requiredNamespaces[SupportedNamespace.COSMOS]?.events ?? []),
+          ...(optionalNamespaces[SupportedNamespace.COSMOS]?.events ?? []),
+        ]),
+      ];
+
+      return {
+        chains: [...new Set(dataToSend.map((e) => e.chain))],
+        methods,
+        events,
+        accounts: dataToSend.map((e) => e.account),
+      };
+    },
+    [session, accounts.data, walletInfo, walletCapabilities, selectedAccounts],
+  );
+
   const buildSupportedNamespaces = useCallback(
     (session: SessionTypes.Struct | ProposalTypes.Struct) => {
       const { requiredNamespaces, optionalNamespaces } = session;
@@ -435,6 +514,15 @@ export function useSupportedNamespaces(
           optionalNamespaces,
         );
       }
+      if (
+        ("cosmos" in requiredNamespaces || "cosmos" in optionalNamespaces) &&
+        isCosmosSupportEnabled(walletInfo)
+      ) {
+        supportedNamespaces[SupportedNamespace.COSMOS] = buildCosmosNamespace(
+          requiredNamespaces,
+          optionalNamespaces,
+        );
+      }
       return supportedNamespaces;
     },
     [
@@ -445,6 +533,7 @@ export function useSupportedNamespaces(
       buildXrpNamespace,
       buildSolanaNamespace,
       buildTezosNamespace,
+      buildCosmosNamespace,
     ],
   );
 

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -16,6 +16,8 @@ import { OneClickAuthPayload } from "@/types/types";
 import {
   getErrorMessage,
   isBIP122Chain,
+  isCosmosChain,
+  isCosmosSupportEnabled,
   isEIP155Chain,
   isRippleChain,
   isSolanaChain,
@@ -36,6 +38,7 @@ import { useTranslation } from "react-i18next";
 import { ZodError } from "zod";
 import { isWalletRequest } from "../utils/helper.util";
 import { handleBIP122Request } from "./requestHandlers/BIP122";
+import { handleCosmosRequest } from "./requestHandlers/Cosmos";
 import { handleEIP155Request } from "./requestHandlers/EIP155";
 import { handleXrpRequest } from "./requestHandlers/Ripple";
 import { handleSolanaRequest } from "./requestHandlers/Solana";
@@ -279,6 +282,27 @@ export default function useWalletConnect() {
               chainId,
               accounts.data.filter((account) =>
                 sessionTezosAddresses.has(account.address),
+              ),
+              client,
+              walletKit,
+            );
+          } else if (
+            isCosmosChain(chainId, request) &&
+            isCosmosSupportEnabled(walletInfo)
+          ) {
+            const session = walletKit.engine.signClient.session.get(topic);
+            const sessionCosmosAddresses = new Set(
+              (session?.namespaces.cosmos?.accounts ?? []).map(
+                (account) => account.split(":")[2],
+              ),
+            );
+            await handleCosmosRequest(
+              request,
+              topic,
+              id,
+              chainId,
+              accounts.data.filter((account) =>
+                sessionCosmosAddresses.has(account.address),
               ),
               client,
               walletKit,

--- a/src/utils/__tests__/cosmos.test.ts
+++ b/src/utils/__tests__/cosmos.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { hexToBase64 } from "../cosmos";
+
+describe("hexToBase64", () => {
+  it("converts a compressed secp256k1 pubkey hex to base64", () => {
+    const hex = "02" + "ab".repeat(32); // 33-byte compressed pubkey
+    expect(hexToBase64(hex)).toBe(Buffer.from(hex, "hex").toString("base64"));
+  });
+
+  it("strips a 0x prefix before decoding", () => {
+    expect(hexToBase64("0xab")).toBe(hexToBase64("ab"));
+  });
+
+  it("round-trips a 64-byte signature", () => {
+    const sigHex = "cd".repeat(64);
+    expect(Buffer.from(hexToBase64(sigHex), "base64").toString("hex")).toBe(
+      sigHex,
+    );
+  });
+});

--- a/src/utils/__tests__/helper.util.test.ts
+++ b/src/utils/__tests__/helper.util.test.ts
@@ -8,6 +8,8 @@ import {
   getErrorMessage,
   getNamespace,
   getTicker,
+  isCosmosChain,
+  isCosmosSupportEnabled,
   isEIP155Chain,
   isSolanaSupportEnabled,
   isTezosChain,
@@ -328,6 +330,61 @@ describe("isTezosSupportEnabled", () => {
       isTezosSupportEnabled(["message.sign", "account.getPublicKey"]),
     ).toBe(false);
     expect(isTezosSupportEnabled([])).toBe(false);
+  });
+});
+
+describe("isCosmosChain", () => {
+  it("matches the registered Babylon chain id", () => {
+    expect(isCosmosChain("cosmos:bbn-1")).toBe(true);
+  });
+
+  it("does not match unregistered cosmos chains", () => {
+    // Exact match only — another cosmos chain must not reach the babylon handler.
+    expect(isCosmosChain("cosmos:osmosis-1")).toBe(false);
+    expect(isCosmosChain("cosmos:1")).toBe(false);
+  });
+
+  it("does not match other namespaces", () => {
+    expect(isCosmosChain("eip155:1")).toBe(false);
+    expect(isCosmosChain("tezos:mainnet")).toBe(false);
+  });
+});
+
+describe("isCosmosSupportEnabled", () => {
+  it("returns true for supported desktop versions at/above the minimum", () => {
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "4.11.0")),
+    ).toBe(true);
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "4.12.0")),
+    ).toBe(true);
+  });
+
+  it("returns false for desktop versions below the minimum", () => {
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "4.10.9")),
+    ).toBe(false);
+  });
+
+  it("returns true for supported mobile versions at/above the minimum", () => {
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("ledger-live-mobile", "4.11.0")),
+    ).toBe(true);
+  });
+
+  it("returns false for mobile versions below the minimum", () => {
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("ledger-live-mobile", "4.10.9")),
+    ).toBe(false);
+  });
+
+  it("returns false for unsupported wallet names and empty versions", () => {
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("other-wallet", "9.0.0")),
+    ).toBe(false);
+    expect(
+      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "")),
+    ).toBe(false);
   });
 });
 

--- a/src/utils/cosmos.ts
+++ b/src/utils/cosmos.ts
@@ -1,0 +1,8 @@
+/**
+ * coin-cosmos stores/returns the compressed secp256k1 public key and produces the detached
+ * signature as non-0x hex strings (via the Wallet API `account.getPublicKey` /
+ * `transaction.signRaw`). The WalletConnect Cosmos RPC expects both as base64.
+ */
+export function hexToBase64(hex: string): string {
+  return Buffer.from(hex.replace(/^0x/, ""), "hex").toString("base64");
+}

--- a/src/utils/helper.util.ts
+++ b/src/utils/helper.util.ts
@@ -1,15 +1,24 @@
 import { BIP122_REQUESTS } from "@/data/methods/BIP122.methods";
+import { COSMOS_REQUESTS } from "@/data/methods/Cosmos.methods";
 import { EIP155_REQUESTS } from "@/data/methods/EIP155Data.methods";
 import { RIPPLE_REQUESTS } from "@/data/methods/Ripple.methods";
 import { SOLANA_REQUESTS } from "@/data/methods/Solana.methods";
 import { TEZOS_REQUESTS } from "@/data/methods/Tezos.methods";
 import { WALLET_REQUESTS } from "@/data/methods/Wallet.methods";
-import { SUPPORTED_NETWORK, TEZOS_CHAINS } from "@/data/network.config";
+import {
+  COSMOS_CHAINS,
+  SUPPORTED_NETWORK,
+  TEZOS_CHAINS,
+} from "@/data/network.config";
 import type { WalletInfo } from "@ledgerhq/wallet-api-client";
 import semver from "semver";
 
 const TEZOS_NAMESPACES = new Set(
   Object.values(TEZOS_CHAINS).map((network) => network.namespace),
+);
+
+const COSMOS_NAMESPACES = new Set(
+  Object.values(COSMOS_CHAINS).map((network) => network.namespace),
 );
 
 /**
@@ -90,6 +99,16 @@ export function isTezosChain(
   return TEZOS_NAMESPACES.has(chain);
 }
 
+export function isCosmosChain(
+  chain: string,
+  // request is passed and used here only for type narrowing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _request?: { method: string; params: any },
+): _request is COSMOS_REQUESTS {
+  // Exact match only: an unregistered `cosmos:*` (e.g. osmosis) must not reach the babylon handler.
+  return COSMOS_NAMESPACES.has(chain);
+}
+
 /**
  * Formats url to to remove protocol
  */
@@ -146,6 +165,22 @@ const SOLANA_MIN_VERSIONS: Record<string, string> = {
 
 /** Check if Solana support should be enabled based on wallet version */
 export const isSolanaSupportEnabled = createSupportChecker(SOLANA_MIN_VERSIONS);
+
+/**
+ * Minimum versions of Ledger Live that support Cosmos (Babylon) over WalletConnect.
+ * Cosmos is version-gated (not capability-gated): the `transaction.signRaw` capability is
+ * already advertised for other families, so its presence does not prove the cosmos
+ * `signRawOperation` + `account.getPublicKey` resolvers are wired into that LL build.
+ * TODO(LIVE-33217): confirm these against the release CHANGELOG — activation depends on
+ * LIVE-33211 (cosmos per-account public key) shipping; 4.11.0 is a projection.
+ */
+const COSMOS_MIN_VERSIONS: Record<string, string> = {
+  "ledger-live-desktop": "4.11.0",
+  "ledger-live-mobile": "4.11.0",
+};
+
+/** Check if Cosmos (Babylon) support should be enabled based on wallet version */
+export const isCosmosSupportEnabled = createSupportChecker(COSMOS_MIN_VERSIONS);
 
 /** Check if XRPL support should be enabled based on wallet capabilities */
 export const isXRPLSupportEnabled = (walletCapabilities: string[]): boolean => {


### PR DESCRIPTION
Add Babylon (cosmos:bbn-1) to WalletConnect supported chains

<!--
Thank you for your contribution! 👍
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Registers **Babylon** (Cosmos Genesis chain, CAIP-2 `cosmos:bbn-1`, ticker `BABY`) in the WalletConnect live app and wires full session negotiation + request handling for it.

**Scope**

- **LIVE-33214 - network config:** `COSMOS_CHAINS` map with the `babylon` entry, spread into `SUPPORTED_NETWORK`; `COSMOS` added to the `SupportedNamespace` enum.
- **LIVE-33216 - docs:** Babylon marked supported in the README currencies table.
- **LIVE-33217 - namespace + request handlers:**
  - `data/methods/Cosmos.methods.ts` — Zod schemas + types for `cosmos_getAccounts` and `cosmos_signAmino` (device is amino-only; `cosmos_signDirect` intentionally omitted).
  - `isCosmosChain` (exact-match against registered cosmos namespaces) and `isCosmosSupportEnabled` (min-LL-version gate, Solana pattern) in `helper.util.ts`.
  - `buildCosmosNamespace` + cosmos branch in `useSupportedNamespaces` — advertises only the two supported methods; `cosmos_signDirect` is dropped from negotiation.
  - `handleCosmosRequest` in `requestHandlers/Cosmos.ts` — `cosmos_getAccounts` (maps pubkey→base64, skips thrown **and** empty pubkeys), `cosmos_signAmino` (`transaction.signRaw`, `broadcast=false`, echoes `signDoc`), `cosmos_signDirect` → rejected `5101`.
  - Dispatch branch in `useWalletConnect` with session-account scoping (Tezos pattern).
  - `babylon` added to `localManifest.json` (local dev).
  - Unit tests for the handler, helpers, namespace builder, and dispatch.
  
**Cross-repo dependencies**

- Manifest exposure to end users is a separate PR against `manifest-api` (LIVE-33215).
- Runtime activation is **version-gated to Ledger Live `4.11.0`** and requires the cosmos `signRawOperation` + `account.getPublicKey` resolvers (LIVE-33211) — both merged to `develop`, awaiting the 4.11.0 release cut. `4.11.0` is a projection until the release CHANGELOG confirms it.


### ❓ Context

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->
[LIVE-33214](https://ledgerhq.atlassian.net/browse/LIVE-33214), [LIVE-33216](https://ledgerhq.atlassian.net/browse/LIVE-33216), [LIVE-33214](https://ledgerhq.atlassian.net/browse/LIVE-33214)
### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ