### PR TITLE
refactor: gate Babylon WC support by capability, not LL version

### DIFF
--- a/src/hooks/__tests__/useSupportedNamespaces.test.ts
+++ b/src/hooks/__tests__/useSupportedNamespaces.test.ts
@@ -545,17 +545,17 @@ describe("useSupportedNamespaces", () => {
     expect(result.current.buildSupportedNamespaces(proposal)).toEqual({});
   });
 
-  it("builds the cosmos namespace and drops cosmos_signDirect when the version gate is on", () => {
+  it("builds the cosmos namespace and drops cosmos_signDirect when the capability gate is on", () => {
     const bbn = makeAccount("bbn-1", "babylon", "bbn1abc");
 
     mockedUseAccounts.mockReturnValue({
       data: [bbn],
     } as ReturnType<typeof useAccounts>);
 
-    store.set(walletInfoAtom as never, {
-      wallet: { name: "ledger-live-desktop", version: "4.11.0" },
-      tracking: false,
-    } satisfies WalletInfo["result"]);
+    store.set(walletCapabilitiesAtom as never, [
+      "transaction.signRaw",
+      "account.getPublicKey",
+    ]);
 
     mockedFormatAccountsByChain.mockReturnValue([
       {
@@ -595,14 +595,14 @@ describe("useSupportedNamespaces", () => {
     });
   });
 
-  it("omits the cosmos namespace when the version gate is disabled", () => {
+  it("omits the cosmos namespace when the capability gate is disabled", () => {
     const bbn = makeAccount("bbn-1", "babylon", "bbn1abc");
 
     mockedUseAccounts.mockReturnValue({
       data: [bbn],
     } as ReturnType<typeof useAccounts>);
 
-    // baseWalletInfo is 2.127.0 (< 4.11.0), so cosmos support is off.
+    // walletCapabilities is empty (beforeEach), so cosmos support is off.
     mockedFormatAccountsByChain.mockReturnValue([
       {
         chain: "babylon",

--- a/src/hooks/__tests__/useWalletConnect.test.ts
+++ b/src/hooks/__tests__/useWalletConnect.test.ts
@@ -471,11 +471,11 @@ describe("useWalletConnect", () => {
     });
   });
 
-  it("dispatches cosmos requests to the cosmos handler when the version gate is on", async () => {
-    store.set(walletInfoAtom as never, {
-      wallet: { name: "ledger-live-desktop", version: "4.11.0" },
-      tracking: false,
-    });
+  it("dispatches cosmos requests to the cosmos handler when the capability gate is on", async () => {
+    store.set(walletCapabilitiesAtom as never, [
+      "transaction.signRaw",
+      "account.getPublicKey",
+    ]);
 
     mountHook();
 
@@ -495,10 +495,10 @@ describe("useWalletConnect", () => {
   });
 
   it("scopes cosmos requests to the session-approved accounts", async () => {
-    store.set(walletInfoAtom as never, {
-      wallet: { name: "ledger-live-desktop", version: "4.11.0" },
-      tracking: false,
-    });
+    store.set(walletCapabilitiesAtom as never, [
+      "transaction.signRaw",
+      "account.getPublicKey",
+    ]);
 
     const approved = { id: "bbn-1", address: "bbn1approved", currency: "babylon" };
     const unapproved = { id: "bbn-2", address: "bbn1other", currency: "babylon" };
@@ -531,8 +531,9 @@ describe("useWalletConnect", () => {
     expect(mockedHandleCosmosRequest.mock.calls[0][4]).toEqual([approved]);
   });
 
-  it("rejects cosmos requests when the version gate is disabled", async () => {
-    // Default walletInfo is 2.127.0 (< 4.11.0), so cosmos support is off.
+  it("rejects cosmos requests when the capability gate is disabled", async () => {
+    // Default walletCapabilities is ["transaction.signRaw"] (no account.getPublicKey),
+    // so cosmos support is off.
     mountHook();
 
     walletKitListeners.get("session_request")?.({

--- a/src/hooks/useSupportedNamespaces.ts
+++ b/src/hooks/useSupportedNamespaces.ts
@@ -516,7 +516,7 @@ export function useSupportedNamespaces(
       }
       if (
         ("cosmos" in requiredNamespaces || "cosmos" in optionalNamespaces) &&
-        isCosmosSupportEnabled(walletInfo)
+        isCosmosSupportEnabled(walletCapabilities)
       ) {
         supportedNamespaces[SupportedNamespace.COSMOS] = buildCosmosNamespace(
           requiredNamespaces,

--- a/src/hooks/useWalletConnect.ts
+++ b/src/hooks/useWalletConnect.ts
@@ -288,7 +288,7 @@ export default function useWalletConnect() {
             );
           } else if (
             isCosmosChain(chainId, request) &&
-            isCosmosSupportEnabled(walletInfo)
+            isCosmosSupportEnabled(walletCapabilities)
           ) {
             const session = walletKit.engine.signClient.session.get(topic);
             const sessionCosmosAddresses = new Set(

--- a/src/utils/__tests__/helper.util.test.ts
+++ b/src/utils/__tests__/helper.util.test.ts
@@ -351,40 +351,19 @@ describe("isCosmosChain", () => {
 });
 
 describe("isCosmosSupportEnabled", () => {
-  it("returns true for supported desktop versions at/above the minimum", () => {
+  it("requires transaction.signRaw and account.getPublicKey", () => {
     expect(
-      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "4.11.0")),
-    ).toBe(true);
-    expect(
-      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "4.12.0")),
-    ).toBe(true);
-  });
-
-  it("returns false for desktop versions below the minimum", () => {
-    expect(
-      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "4.10.9")),
-    ).toBe(false);
-  });
-
-  it("returns true for supported mobile versions at/above the minimum", () => {
-    expect(
-      isCosmosSupportEnabled(createWalletInfo("ledger-live-mobile", "4.11.0")),
+      isCosmosSupportEnabled([
+        "transaction.signRaw",
+        "account.getPublicKey",
+      ]),
     ).toBe(true);
   });
 
-  it("returns false for mobile versions below the minimum", () => {
-    expect(
-      isCosmosSupportEnabled(createWalletInfo("ledger-live-mobile", "4.10.9")),
-    ).toBe(false);
-  });
-
-  it("returns false for unsupported wallet names and empty versions", () => {
-    expect(
-      isCosmosSupportEnabled(createWalletInfo("other-wallet", "9.0.0")),
-    ).toBe(false);
-    expect(
-      isCosmosSupportEnabled(createWalletInfo("ledger-live-desktop", "")),
-    ).toBe(false);
+  it("returns false when any capability is missing", () => {
+    expect(isCosmosSupportEnabled(["transaction.signRaw"])).toBe(false);
+    expect(isCosmosSupportEnabled(["account.getPublicKey"])).toBe(false);
+    expect(isCosmosSupportEnabled([])).toBe(false);
   });
 });
 

--- a/src/utils/helper.util.ts
+++ b/src/utils/helper.util.ts
@@ -167,20 +167,28 @@ const SOLANA_MIN_VERSIONS: Record<string, string> = {
 export const isSolanaSupportEnabled = createSupportChecker(SOLANA_MIN_VERSIONS);
 
 /**
- * Minimum versions of Ledger Live that support Cosmos (Babylon) over WalletConnect.
- * Cosmos is version-gated (not capability-gated): the `transaction.signRaw` capability is
- * already advertised for other families, so its presence does not prove the cosmos
- * `signRawOperation` + `account.getPublicKey` resolvers are wired into that LL build.
- * TODO(LIVE-33217): confirm these against the release CHANGELOG — activation depends on
- * LIVE-33211 (cosmos per-account public key) shipping; 4.11.0 is a projection.
+ * Check if Cosmos (Babylon) support should be enabled based on wallet capabilities.
+ * The cosmos handler calls `transaction.signRaw` (cosmos_signAmino) and
+ * `account.getPublicKey` (cosmos_getAccounts), so the host must advertise both.
+ *
+ * KNOWN, ACCEPTED FALSE POSITIVE — do not "fix" by removing the check:
+ * `walletCapabilities` (from `wallet.capabilities()`) is a build-global list of registered
+ * wallet-api methods, NOT a per-family signal. Both `transaction.signRaw` and
+ * `account.getPublicKey` are advertised generically by Ledger Live for other families that
+ * already use them, so this returns true on any LL build that advertises them but has not wired
+ * the cosmos resolvers (cosmos `signRawOperation` + the `cosmos` entry in
+ * `ACCOUNT_PUBLIC_KEY_RESOLVERS`). On such a build Babylon is offered but requests fail
+ * (`getPublicKey` throws "not implemented"); the handler degrades gracefully (skips
+ * empty/throwing accounts, rejects the session) rather than crashing. A per-family capability
+ * (e.g. `cosmos.signRaw`) would be needed to close the window entirely.
+ * (Deliberately chosen over the previous min-LL-version gate for LIVE-27227.)
  */
-const COSMOS_MIN_VERSIONS: Record<string, string> = {
-  "ledger-live-desktop": "4.11.0",
-  "ledger-live-mobile": "4.11.0",
+export const isCosmosSupportEnabled = (walletCapabilities: string[]): boolean => {
+  return (
+    walletCapabilities.includes("transaction.signRaw") &&
+    walletCapabilities.includes("account.getPublicKey")
+  );
 };
-
-/** Check if Cosmos (Babylon) support should be enabled based on wallet version */
-export const isCosmosSupportEnabled = createSupportChecker(COSMOS_MIN_VERSIONS);
 
 /** Check if XRPL support should be enabled based on wallet capabilities */
 export const isXRPLSupportEnabled = (walletCapabilities: string[]): boolean => {

--- a/src/utils/helper.util.ts
+++ b/src/utils/helper.util.ts
@@ -178,9 +178,10 @@ export const isSolanaSupportEnabled = createSupportChecker(SOLANA_MIN_VERSIONS);
  * already use them, so this returns true on any LL build that advertises them but has not wired
  * the cosmos resolvers (cosmos `signRawOperation` + the `cosmos` entry in
  * `ACCOUNT_PUBLIC_KEY_RESOLVERS`). On such a build Babylon is offered but requests fail
- * (`getPublicKey` throws "not implemented"); the handler degrades gracefully (skips
- * empty/throwing accounts, rejects the session) rather than crashing. A per-family capability
- * (e.g. `cosmos.signRaw`) would be needed to close the window entirely.
+ * (`getPublicKey` throws "not implemented"): `cosmos_getAccounts` skips the unusable accounts
+ * and accepts with an empty list, while `cosmos_signAmino` rethrows and the dispatch catch
+ * answers the dApp with a JSON-RPC error (`txDeclined`) — no crash, but a broken connect UX.
+ * A per-family capability (e.g. `cosmos.signRaw`) would be needed to close the window entirely.
  * (Deliberately chosen over the previous min-LL-version gate for LIVE-27227.)
  */
 export const isCosmosSupportEnabled = (walletCapabilities: string[]): boolean => {


### PR DESCRIPTION
<!--
Thank you for your contribution! 👍
Disclaimer: Pull Requests that do not comply with the rules will be arbitrarily closed.
-->

### 📝 Description

Switches the Babylon (`cosmos:bbn-1`) WalletConnect support gate from a **minimum
Ledger Live version** check to a **wallet-capability** check, mirroring how Tezos
and XRPL are already gated.

`isCosmosSupportEnabled` now takes `walletCapabilities` and returns true only when
the host advertises both methods the cosmos handler actually calls:

- `transaction.signRaw` — `cosmos_signAmino`
- `account.getPublicKey` — `cosmos_getAccounts`

(`message.sign` is intentionally **not** required — unlike Tezos, cosmos has no
message-signing method.)

Changes:
- `src/utils/helper.util.ts` — `isCosmosSupportEnabled(walletCapabilities: string[])`;
  removed `COSMOS_MIN_VERSIONS` and the version-based checker.
- `src/hooks/useSupportedNamespaces.ts`, `src/hooks/useWalletConnect.ts` — the
  namespace-build and dispatch gates now pass `walletCapabilities`.
- Tests updated to drive the gate via `walletCapabilitiesAtom` / capability lists
  instead of wallet version.

### ❓ Context

Why: the previous version gate required pinning a projected LL version (`4.11.0`)
and waiting for that exact release to be cut before Babylon could activate. A
capability gate activates automatically as soon as a host build advertises the
required wallet-api methods, and is consistent with the Tezos/XRPL gates already
in the app.

- **Linked resource(s)**: [] <!-- Attach any ticket number if relevant. like [LIVE-9879] (JIRA / Github issue number) -->

### 📸 Demo

<!--
For visual features, please attach screenshots or video recordings to demonstrate the changes.
For bugfixes, you can drop this section.
-->

### 🚀 Expectations to reach

_Pull Requests must pass the CI and be internally validated in order to be merged._

<!-- If any of the expectations are not met please explain the reason in detail. -->


[LIVE-9879]: https://ledgerhq.atlassian.net/browse/LIVE-9879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ